### PR TITLE
refactor tests to use psql database

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black pytest coverage
+        pip install black pytest pytest-docker coverage
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Black Code Formatter
       uses: lgeiger/black-action@v1.0.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+import os
+import psycopg2
+
+
+@pytest.fixture(scope="session")
+def docker_compose_file(pytestconfig):
+    return os.path.join(str(pytestconfig.rootdir), "tests", "docker-compose.yml")
+
+
+def is_responsive_psql(url):
+    try:
+        conn = psycopg2.connect(
+            f"dbname='postgres' user='postgres' host=localhost password='postgres'"
+        )
+        conn.close()
+        return True
+    except:
+        return False
+
+
+@pytest.fixture(scope="session")
+def psql_service(docker_ip, docker_services):
+    """Ensure that Kafka service is up and responsive."""
+    # `port_for` takes a container port and returns the corresponding host port
+    port = docker_services.port_for("postgres", 5432)
+    server = "{}:{}".format(docker_ip, port)
+    docker_services.wait_until_responsive(
+        timeout=30.0, pause=0.1, check=lambda: is_responsive_psql(server)
+    )
+    return server

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3"
+services:
+  postgres:
+    image: postgres
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_DB=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - 5432:5432

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,4 @@
 TESTING = True
-DATABASE = {"SQL": {
-    "SQLALCHEMY_DATABASE_URL": "sqlite:///:memory:"}
-}
+SQLALCHEMY_DATABASE_URL = f"postgresql://postgres:postgres@localhost:5432/postgres"
 
+DATABASE = {"SQL": {"SQLALCHEMY_DATABASE_URL": SQLALCHEMY_DATABASE_URL}}

--- a/tests/test_classifiers.py
+++ b/tests/test_classifiers.py
@@ -2,12 +2,12 @@ from fixtures import client, db, BaseQuery, models
 from unittest.mock import patch
 
 
-def test_classifier_list(client):
+def test_classifier_list(psql_service, client):
     r = client.get("/classifiers/")
     # TODO Replace with actual assertion when classes are not hardcoded
     assert len(r.json) is not None
 
 
-def test_classifier_classes(client):
-    r = client.get("/classifiers/Stamp/classes")
+def test_classifier_classes(psql_service, client):
+    r = client.get("/classifiers/C1/1.0.0-test/classes")
     assert len(r.json) is not None

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1,25 +1,31 @@
 from fixtures import client
 
-def test_get_lightcurve(client):
+
+def test_get_lightcurve(psql_service, client):
     rv = client.get("objects/ZTF1/lightcurve")
     assert rv.status_code == 200
 
-def test_get_lightcurve_not_found(client):
+
+def test_get_lightcurve_not_found(psql_service, client):
     rv = client.get("objects/ZTF2/lightcurve")
     assert rv.status_code == 404
 
-def test_get_detections(client):
+
+def test_get_detections(psql_service, client):
     rv = client.get("objects/ZTF1/detections")
     assert rv.status_code == 200
 
-def test_get_detections_not_found(client):
+
+def test_get_detections_not_found(psql_service, client):
     rv = client.get("objects/ZTF2/detections")
     assert rv.status_code == 404
 
-def test_get_non_detections(client):
+
+def test_get_non_detections(psql_service, client):
     rv = client.get("objects/ZTF1/non_detections")
     assert rv.status_code == 200
 
-def test_get_non_detections_not_found(client):
+
+def test_get_non_detections_not_found(psql_service, client):
     rv = client.get("objects/ZTF2/non_detections")
     assert rv.status_code == 404

--- a/tests/test_magstats.py
+++ b/tests/test_magstats.py
@@ -1,9 +1,11 @@
-from fixtures import client 
+from fixtures import client
 
-def test_magstats(client):
+
+def test_magstats(psql_service, client):
     r = client.get("objects/ZTF1/magstats")
     assert r.status_code == 200
 
-def test_magstats_not_found(client):
+
+def test_magstats_not_found(psql_service, client):
     r = client.get("objects/ZTF2/magstats")
     assert r.status_code == 404

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -2,7 +2,7 @@ from api.sql.astro_object import astro_object as AstroObjectResource
 from fixtures import client, db, BaseQuery, models
 
 
-def test_conesearch(client):
+def test_conesearch(psql_service, client):
     resource = AstroObjectResource.ObjectList()
     args = {"ra": 1, "dec": 1, "radius": 0.1}
     params = resource._convert_conesearch_args(args)
@@ -10,17 +10,18 @@ def test_conesearch(client):
     assert "q3c_radial_query(meanra, meandec,:ra, :dec, :radius)" in str(statement)
 
 
-def test_order_by_desc(client):
+def test_order_by_desc(psql_service, client):
     obj = models.Object(oid="ZTF2", firstmjd=2.0)
     db.session.add(obj)
     db.session.commit()
+    db.session.close()
     args = {"order_by": "firstmjd", "order_mode": "DESC"}
     r = client.get("/objects/", query_string=args)
     assert len(r.json["items"]) == 2
     assert r.json["items"][0]["oid"] == "ZTF2"
 
 
-def test_order_by_asc(client):
+def test_order_by_asc(psql_service, client):
     obj = models.Object(oid="ZTF2", firstmjd=2.0)
     db.session.add(obj)
     db.session.commit()
@@ -30,26 +31,7 @@ def test_order_by_asc(client):
     assert r.json["items"][0]["oid"] == "ZTF1"
 
 
-def test_order_by_class_attribute_desc(client):
-    obj = models.Object(oid="ZTF2", firstmjd=2.0)
-    classification = obj.probabilities.append(
-        models.Probability(
-            class_name="SN",
-            probability=0.5,
-            classifier_name="C1",
-            classifier_version="1.0.0-test",
-            ranking=2,
-        )
-    )
-    db.session.add(obj)
-    db.session.commit()
-    args = {"order_by": "probability", "order_mode": "DESC"}
-    r = client.get("/objects/", query_string=args)
-    assert len(r.json["items"]) == 2
-    assert r.json["items"][0]["oid"] == "ZTF1"
-
-
-def test_order_by_class_attribute_asc(client):
+def test_order_by_class_attribute_desc(psql_service, client):
     obj = models.Object(oid="ZTF2", firstmjd=2.0)
     classification = obj.probabilities.append(
         models.Probability(
@@ -62,25 +44,54 @@ def test_order_by_class_attribute_asc(client):
     )
     db.session.add(obj)
     db.session.commit()
-    args = {"order_by": "probability", "order_mode": "ASC"}
+    args = {
+        "classifier": "C1",
+        "classifier_version": "1.0.0-test",
+        "order_by": "probability",
+        "order_mode": "DESC",
+    }
+    r = client.get("/objects/", query_string=args)
+    assert len(r.json["items"]) == 2
+    assert r.json["items"][0]["oid"] == "ZTF1"
+
+
+def test_order_by_class_attribute_asc(psql_service, client):
+    obj = models.Object(oid="ZTF2", firstmjd=2.0)
+    classification = obj.probabilities.append(
+        models.Probability(
+            class_name="VS",
+            probability=0.5,
+            classifier_name="C1",
+            classifier_version="1.0.0-test",
+            ranking=1,
+        )
+    )
+    db.session.add(obj)
+    db.session.commit()
+    args = {
+        "classifier": "C1",
+        "classifier_version": "1.0.0-test",
+        "order_by": "probability",
+        "order_mode": "ASC",
+    }
     r = client.get("/objects/", query_string=args)
     assert len(r.json["items"]) == 2
     assert r.json["items"][0]["oid"] == "ZTF2"
 
 
-def test_object_list(client):
+def test_object_list(psql_service, client):
     rv = client.get("/objects/")
     assert isinstance(rv.json["items"], list)
     assert len(rv.json["items"]) == 1
     assert rv.json["items"][0]["oid"] == "ZTF1"
 
 
-def test_objects_list_not_found(client):
+def test_objects_list_not_found(psql_service, client):
     rv = client.get("/objects/", query_string={"classifier": "Fake"})
-    assert rv.status_code == 404
+    assert rv.json["total"] == 0
 
 
-def test_date_query_first(client):
+def test_date_query_first(psql_service, client):
     obj = models.Object(oid="ZTF2", firstmjd=2.0)
     db.session.add(obj)
     db.session.commit()
@@ -90,7 +101,7 @@ def test_date_query_first(client):
     assert len(rv.json["items"]) == 1
 
 
-def test_date_query_first_2(client):
+def test_date_query_first_2(psql_service, client):
     obj = models.Object(oid="ZTF2", firstmjd=2.0)
     db.session.add(obj)
     db.session.commit()
@@ -100,7 +111,7 @@ def test_date_query_first_2(client):
     assert len(rv.json["items"]) == 1
 
 
-def test_date_query_last(client):
+def test_date_query_last(psql_service, client):
     obj = models.Object(oid="ZTF2", lastmjd=2.0)
     db.session.add(obj)
     db.session.commit()
@@ -110,7 +121,7 @@ def test_date_query_last(client):
     assert len(rv.json["items"]) == 1
 
 
-def test_date_query_last_2(client):
+def test_date_query_last_2(psql_service, client):
     obj = models.Object(oid="ZTF2", lastmjd=2.0)
     db.session.add(obj)
     db.session.commit()
@@ -120,7 +131,7 @@ def test_date_query_last_2(client):
     assert len(rv.json["items"]) == 1
 
 
-def test_ndet_query(client):
+def test_ndet_query(psql_service, client):
     obj = models.Object(oid="ZTF2", ndet=2)
     db.session.add(obj)
     db.session.commit()
@@ -130,7 +141,7 @@ def test_ndet_query(client):
     assert rv.json["items"][0]["oid"] == "ZTF1"
 
 
-def test_ndet_query_2(client):
+def test_ndet_query_2(psql_service, client):
     obj = models.Object(oid="ZTF2", ndet=2)
     db.session.add(obj)
     db.session.commit()
@@ -140,34 +151,35 @@ def test_ndet_query_2(client):
     assert rv.json["items"][0]["oid"] == "ZTF2"
 
 
-def test_classifier_query(client):
+def test_classifier_query(psql_service, client):
     args = {"classifier": "C1"}
     rv = client.get("/objects/", query_string=args)
     assert len(rv.json["items"]) == 1
     assert rv.json["items"][0]["oid"] == "ZTF1"
 
 
-def test_class_query(client):
+def test_class_query(psql_service, client):
     args = {"class": "SN"}
     rv = client.get("/objects/", query_string=args)
     assert len(rv.json["items"]) == 1
     assert rv.json["items"][0]["oid"] == "ZTF1"
 
 
-def test_class_classifier_query(client):
+def test_class_classifier_query(psql_service, client):
     args = {"classifier": "C1", "class": "SN"}
     rv = client.get("/objects/", query_string=args)
     assert len(rv.json["items"]) == 1
     assert rv.json["items"][0]["oid"] == "ZTF1"
 
 
-def test_class_classifier_query_not_found(client):
+def test_class_classifier_query_not_found(psql_service, client):
     args = {"classifier": "C1", "class": "fake"}
     rv = client.get("/objects/", query_string=args)
-    assert rv.status_code == 404
+    assert len(rv.json["items"]) == 0
+    assert rv.json["total"] == 0
 
 
-def test_single_object_query(client):
+def test_single_object_query(psql_service, client):
     rv = client.get("/objects/ZTF1")
     assert rv.status_code == 200
     assert rv.json["oid"] == "ZTF1"

--- a/tests/test_probabilities.py
+++ b/tests/test_probabilities.py
@@ -1,10 +1,12 @@
-from fixtures import client 
+from fixtures import client
 
-def test_get_probabilities(client):
+
+def test_get_probabilities(psql_service, client):
     r = client.get("objects/ZTF1/probabilities")
     assert r.status_code == 200
     assert isinstance(r.json, list)
 
-def test_get_probabilities_not_found(client):
+
+def test_get_probabilities_not_found(psql_service, client):
     r = client.get("objects/ZTF2/probabilities")
     assert r.status_code == 404


### PR DESCRIPTION
Tests are using pytest-docker to create a psql databasse in a docker container and run tests against that.