### PR TITLE
refactor mongo interface bad mongo object definition

### DIFF
--- a/api/database_access/interfaces.py
+++ b/api/database_access/interfaces.py
@@ -94,7 +94,8 @@ class MongoInterface(DBInterface):
     detections = mongo_db.query().find_all(
       model=mongo_models.Detection,
       filter_by={
-        "aid": object_id
+        "aid": object_id,
+        "tid": {"$regex": 'ATLAS*'}
       },
       paginate=False
     )
@@ -106,7 +107,8 @@ class MongoInterface(DBInterface):
     non_detections = mongo_db.query().find_all(
       model=mongo_models.NonDetection,
       filter_by={
-        "aid": object_id
+        "aid": object_id,
+        "tid": {"$regex": 'ATLAS*'}
       },
       paginate=False
     )

--- a/api/database_access/interfaces.py
+++ b/api/database_access/interfaces.py
@@ -77,10 +77,50 @@ class MongoInterface(DBInterface):
   survey_id = "atlas"
 
   @classmethod
+  def _get_object(cls, object_id):
+    astro_object = mongo_db.query().find_one(
+      model=mongo_models.Object,
+      filter_by={
+        "oid": object_id
+      }
+    )
+    if astro_object:
+      return astro_object
+    else:
+      raise ObjectNotFound(object_id=object_id, survey_id=cls.survey_id)
+
+  @classmethod
+  def _get_detections(cls, object_id):
+    detections = mongo_db.query().find_all(
+      model=mongo_models.Detection,
+      filter_by={
+        "aid": object_id
+      },
+      paginate=False
+    )
+
+    return list(detections)
+
+  @classmethod
+  def _get_non_detections(cls, object_id):
+    non_detections = mongo_db.query().find_all(
+      model=mongo_models.NonDetection,
+      filter_by={
+        "aid": object_id
+      },
+      paginate=False
+    )
+
+    return list(non_detections)
+  
+  @classmethod
   def get_light_curve(cls, object_id):
+    astro_object = cls._get_object(object_id)
+    aid = astro_object["aid"]
+    
     light_curve = {
-      "detections": cls.get_detections(object_id),
-      "non_detections": cls._get_non_detections(object_id)
+      "detections": cls._get_detections(aid),
+      "non_detections": cls._get_non_detections(aid)
     }
 
     for det in light_curve["detections"]:
@@ -90,43 +130,24 @@ class MongoInterface(DBInterface):
 
   @classmethod
   def get_detections(cls, object_id):
-    """
-      There is no object without detections
-    """
-    detections = mongo_db.query().find_all(
-      model=mongo_models.Detection,
-      filter_by={
-        "oid": object_id
-      },
-      paginate=False
-    )
+    astro_object = cls._get_object(object_id)
+    aid = astro_object["aid"]
+    
+    detections = cls._get_detections(aid)
 
-    if detections:
-      detections = list(detections)
-      if len(detections) > 0:
-        return list(detections)
-      else:
-        raise ObjectNotFound(object_id=object_id, survey_id=cls.survey_id)  
+    if detections and len(detections) > 0:
+        return detections
     else:
       raise ObjectNotFound(object_id=object_id, survey_id=cls.survey_id)
 
   @classmethod
-  def _get_non_detections(cls, object_id):
-    non_detections = mongo_db.query().find_all(
-      model=mongo_models.NonDetection,
-      filter_by={
-        "oid": object_id
-      },
-      paginate=False
-    )
-
-    return list(non_detections)
-
-  @classmethod
   def get_non_detections(cls, object_id):
-    non_detections = cls._get_non_detections(object_id)
+    astro_object = cls._get_object(object_id)
+    aid = astro_object["aid"]
+
+    non_detections = cls._get_non_detections(aid)
     
-    if len(non_detections) > 0:
+    if non_detections and len(non_detections) > 0:
       return non_detections
     else:
       raise ObjectNotFound(object_id=object_id, survey_id=cls.survey_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,8 +183,17 @@ def client():
 
             # mongo data
             mongo_object = mongo_models.Object(
-                aid="aid",
-                oid="ATLAS1",
+                aid="AID_ATLAS1",
+                oid=["ATLAS1"],
+                lastmjd="lastmjd",
+                firstmjd="firstmjd",
+                meanra=100.0,
+                meandec=50.0,
+                ndet="ndet"
+            )
+            mongo_object_2 = mongo_models.Object(
+                aid="AID_ATLAS2",
+                oid=["ATLAS2", "ZTF2"],
                 lastmjd="lastmjd",
                 firstmjd="firstmjd",
                 meanra=100.0,
@@ -193,8 +202,8 @@ def client():
             )
             mongo_detections = mongo_models.Detection(
                 tid="tid",
-                aid="aid",
-                oid="ATLAS1",
+                aid="AID_ATLAS1",
+                oid=["ATLAS1"],
                 candid="candid",
                 mjd=1,
                 fid=1,
@@ -219,8 +228,8 @@ def client():
             )
             mongo_detections_2 = mongo_models.Detection(
                 tid="tid",
-                aid="aid",
-                oid="ATLAS2",
+                aid="AID_ATLAS2",
+                oid=["ATLAS2", "ZTF2"],
                 candid="candid",
                 mjd=1,
                 fid=1,
@@ -244,14 +253,15 @@ def client():
                 rbversion="rbversion"
             )
             moongo_non_detections = mongo_models.NonDetection(
-                aid="aid",
-                oid="ATLAS1",
+                aid="AID_ATLAS1",
+                oid=["ATLAS1"],
                 tid="sid",
                 mjd=1,
                 diffmaglim=1,
                 fid=1
             )
             mongo_db.query().get_or_create(mongo_object, model=mongo_models.Object)
+            mongo_db.query().get_or_create(mongo_object_2, model=mongo_models.Object)
             mongo_db.query().get_or_create(mongo_detections, model=mongo_models.Detection)
             mongo_db.query().get_or_create(mongo_detections_2, model=mongo_models.Detection)
             mongo_db.query().get_or_create(moongo_non_detections, model=mongo_models.NonDetection)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,7 +201,7 @@ def client():
                 ndet="ndet"
             )
             mongo_detections = mongo_models.Detection(
-                tid="tid",
+                tid="ATLAS01",
                 aid="AID_ATLAS1",
                 oid=["ATLAS1"],
                 candid="candid",
@@ -227,7 +227,7 @@ def client():
                 rbversion="rbversion"
             )
             mongo_detections_2 = mongo_models.Detection(
-                tid="tid",
+                tid="ATLAS02",
                 aid="AID_ATLAS2",
                 oid=["ATLAS2", "ZTF2"],
                 candid="candid",
@@ -255,7 +255,7 @@ def client():
             moongo_non_detections = mongo_models.NonDetection(
                 aid="AID_ATLAS1",
                 oid=["ATLAS1"],
-                tid="sid",
+                tid="ATLAS01",
                 mjd=1,
                 diffmaglim=1,
                 fid=1

--- a/tests/test_database_access.py
+++ b/tests/test_database_access.py
@@ -15,16 +15,16 @@ def test_get_light_curve_mongo(mongo_service, psql_service, client):
   result = command.execute()
 
   assert len(result["detections"]) == 1
-  assert result["detections"][0]["oid"] == "ATLAS1"
+  assert result["detections"][0]["aid"] == "AID_ATLAS1"
 
   assert len(result["non_detections"]) == 1
-  assert result["non_detections"][0]["oid"] == "ATLAS1"
+  assert result["non_detections"][0]["aid"] == "AID_ATLAS1"
 
-  command = GetLightCurve("ATLAS2", ATLAS_ID)
+  command = GetLightCurve("ZTF2", ATLAS_ID)
   result = command.execute()
 
   assert len(result["detections"]) == 1
-  assert result["detections"][0]["oid"] == "ATLAS2"
+  assert result["detections"][0]["aid"] == "AID_ATLAS2"
 
   assert len(result["non_detections"]) == 0
   assert result["non_detections"] == []


### PR DESCRIPTION
The oid and aid was beeing wrongly used in the code. 
oid wasnt been considered as a list
and aid wasnt been used for the search

for this:
- fix the objects for testing
- added "private" methods in the mongo interface to ask for objects, detection and non detections
- the "public" methods use the private ones to get the objects from oiid and the detections and non detections with the aid.
- fixed the tests to use and check the new system.