### PR TITLE
Option to limit number of (non)detections returned

### DIFF
--- a/src/api/resources/light_curve/light_curve.py
+++ b/src/api/resources/light_curve/light_curve.py
@@ -26,7 +26,7 @@ class LightCurve(Resource):
     @decorators.check_permissions_decorator
     @api.doc("lightcurve")
     @api.marshal_with(models.light_curve_model, skip_none=True)
-    @api.expect(parsers.survey_id_parser)
+    @api.expect(parsers.filters)
     @inject
     def get(
         self,
@@ -41,7 +41,7 @@ class LightCurve(Resource):
         """
         Gets detections and non detections
         """
-        args = {"aid": id, **parsers.survey_id_parser.parse_args()}
+        args = {"aid": id, **parsers.filters.parse_args()}
         command = command_factory(
             payload=LightCurvePayload(args),
             handler=result_handler,
@@ -60,7 +60,7 @@ class ObjectDetections(Resource):
     @decorators.check_permissions_decorator
     @api.doc("detections")
     @api.marshal_list_with(models.detection_model, skip_none=True)
-    @api.expect(parsers.survey_id_parser)
+    @api.expect(parsers.filters, parsers.pagination, parsers.order)
     @inject
     def get(
         self,
@@ -75,9 +75,11 @@ class ObjectDetections(Resource):
         """
         Just the detections
         """
-        args = {"aid": id, **parsers.survey_id_parser.parse_args()}
+        args = {"aid": id, **parsers.filters.parse_args()}
+        paginate_args = parsers.pagination.parse_args()
+        sort_args = parsers.order.parse_args()
         command = command_factory(
-            payload=LightCurvePayload(args),
+            payload=LightCurvePayload(args, paginate_args, sort_args),
             handler=result_handler,
         )
         command.execute()
@@ -94,7 +96,7 @@ class NonDetections(Resource):
     @decorators.check_permissions_decorator
     @api.doc("non_detections")
     @api.marshal_list_with(models.non_detection_model, skip_none=True)
-    @api.expect(parsers.survey_id_parser)
+    @api.expect(parsers.filters, parsers.pagination, parsers.order)
     @inject
     def get(
         self,
@@ -109,9 +111,11 @@ class NonDetections(Resource):
         """
         Just non detections
         """
-        args = {"aid": id, **parsers.survey_id_parser.parse_args()}
+        args = {"aid": id, **parsers.filters.parse_args()}
+        paginate_args = parsers.pagination.parse_args()
+        sort_args = parsers.order.parse_args()
         command = command_factory(
-            payload=LightCurvePayload(args),
+            payload=LightCurvePayload(args, paginate_args, sort_args),
             handler=result_handler,
         )
         command.execute()

--- a/src/api/resources/light_curve/light_curve.py
+++ b/src/api/resources/light_curve/light_curve.py
@@ -11,9 +11,9 @@ from . import models, parsers
 
 
 api = Namespace("lightcurve", description="LightCurve related operations")
-api.models[models.light_curve_model.name] = models.light_curve_model
-api.models[models.detection_model.name] = models.detection_model
-api.models[models.non_detection_model.name] = models.non_detection_model
+api.models[models.light_curve.name] = models.light_curve
+api.models[models.detection.name] = models.detection
+api.models[models.non_detection.name] = models.non_detection
 
 
 @api.route("/<id>/lightcurve")
@@ -25,7 +25,7 @@ class LightCurve(Resource):
     @decorators.set_filters_decorator(["filter_atlas_lightcurve"])
     @decorators.check_permissions_decorator
     @api.doc("lightcurve")
-    @api.marshal_with(models.light_curve_model, skip_none=True)
+    @api.marshal_with(models.light_curve, skip_none=True)
     @api.expect(parsers.filters)
     @inject
     def get(
@@ -59,7 +59,7 @@ class ObjectDetections(Resource):
     @decorators.set_filters_decorator(["filter_atlas_detections"])
     @decorators.check_permissions_decorator
     @api.doc("detections")
-    @api.marshal_list_with(models.detection_model, skip_none=True)
+    @api.marshal_list_with(models.detection, skip_none=True)
     @api.expect(parsers.filters, parsers.pagination, parsers.order)
     @inject
     def get(
@@ -95,7 +95,7 @@ class NonDetections(Resource):
     @decorators.set_filters_decorator(["filter_atlas_non_detections"])
     @decorators.check_permissions_decorator
     @api.doc("non_detections")
-    @api.marshal_list_with(models.non_detection_model, skip_none=True)
+    @api.marshal_list_with(models.non_detection, skip_none=True)
     @api.expect(parsers.filters, parsers.pagination, parsers.order)
     @inject
     def get(

--- a/src/api/resources/light_curve/models.py
+++ b/src/api/resources/light_curve/models.py
@@ -1,7 +1,7 @@
 from flask_restx import fields, Model
 
 
-detection_model = Model(
+detection = Model(
     "Detection",
     {
         "aid": fields.String,
@@ -24,7 +24,7 @@ detection_model = Model(
     },
 )
 
-non_detection_model = Model(
+non_detection = Model(
     "Non Detection",
     {
         "tid": fields.String,
@@ -34,10 +34,10 @@ non_detection_model = Model(
     },
 )
 
-light_curve_model = Model(
+light_curve = Model(
     "Light Curve",
     {
-        "detections": fields.List(fields.Nested(detection_model)),
-        "non_detections": fields.List(fields.Nested(non_detection_model)),
+        "detections": fields.List(fields.Nested(detection)),
+        "non_detections": fields.List(fields.Nested(non_detection)),
     },
 )

--- a/src/api/resources/light_curve/parsers.py
+++ b/src/api/resources/light_curve/parsers.py
@@ -35,6 +35,7 @@ order.add_argument(
     type=str,
     dest="order_by",
     location="args",
+    choices=["mjd"],
     help="Column used for ordering results",
 )
 order.add_argument(

--- a/src/api/resources/light_curve/parsers.py
+++ b/src/api/resources/light_curve/parsers.py
@@ -11,3 +11,11 @@ survey_id_parser.add_argument(
     help="Survey identifier",
     choices=SURVEY_ID_CHOICES,
 )
+survey_id_parser.add_argument(
+    "mjd",
+    type=float,
+    dest="mjd",
+    location="args",
+    help="Range of detection modified Julian dates",
+    action="append",
+)

--- a/src/api/resources/light_curve/parsers.py
+++ b/src/api/resources/light_curve/parsers.py
@@ -11,14 +11,6 @@ filters.add_argument(
     help="Survey identifier",
     choices=SURVEY_ID_CHOICES,
 )
-filters.add_argument(
-    "mjd",
-    type=float,
-    dest="mjd",
-    location="args",
-    help="Range of detection modified Julian dates",
-    action="append",
-)
 
 
 pagination = reqparse.RequestParser()

--- a/src/api/resources/light_curve/parsers.py
+++ b/src/api/resources/light_curve/parsers.py
@@ -2,8 +2,8 @@ from flask_restx import reqparse
 
 SURVEY_ID_CHOICES = ["ztf", "atlas"]
 
-survey_id_parser = reqparse.RequestParser()
-survey_id_parser.add_argument(
+filters = reqparse.RequestParser()
+filters.add_argument(
     "survey_id",
     type=str,
     dest="survey_id",
@@ -11,11 +11,45 @@ survey_id_parser.add_argument(
     help="Survey identifier",
     choices=SURVEY_ID_CHOICES,
 )
-survey_id_parser.add_argument(
+filters.add_argument(
     "mjd",
     type=float,
     dest="mjd",
     location="args",
     help="Range of detection modified Julian dates",
     action="append",
+)
+
+
+pagination = reqparse.RequestParser()
+pagination.add_argument(
+    "page",
+    type=int,
+    dest="page",
+    location="args",
+    help="Result page to retrieve",
+)
+pagination.add_argument(
+    "page_size",
+    type=int,
+    dest="page_size",
+    location="args",
+    help="Number of results per page",
+)
+
+order = reqparse.RequestParser()
+order.add_argument(
+    "order_by",
+    type=str,
+    dest="order_by",
+    location="args",
+    help="Column used for ordering results",
+)
+order.add_argument(
+    "order_mode",
+    type=str,
+    dest="order_mode",
+    location="args",
+    choices=["ASC", "DESC"],
+    help="Set order as ascending or descending",
 )

--- a/src/core/light_curve/domain/light_curve_payload.py
+++ b/src/core/light_curve/domain/light_curve_payload.py
@@ -14,4 +14,8 @@ class LightCurvePayload(MongoPayload):
             ["$regex", "$options"],
             LightCurveHelpers.generate_tid_regex,
         ),
+        "mjd": MongoFilterRules(["mjd"], ["$gte", "$lte"], LightCurveHelpers.list_of_float)
     }
+    paginate_map = {"page": "page", "per_page": "page_size", "count": "count"}
+    sort_map = {"key": "order_by", "direction": "order_mode"}
+    direction_map = {"ASC": 1, "DESC": -1}

--- a/src/core/light_curve/domain/light_curve_payload.py
+++ b/src/core/light_curve/domain/light_curve_payload.py
@@ -15,7 +15,7 @@ class LightCurvePayload(MongoPayload):
             LightCurveHelpers.generate_tid_regex,
         ),
     }
-    paginate_map = {"page": "page", "per_page": "page_size", "count": "count"}
+    paginate_map = {"page": "page", "per_page": "page_size"}
     sort_map = {"key": "order_by", "direction": "order_mode"}
     direction_map = {"ASC": 1, "DESC": -1}
 

--- a/src/core/light_curve/infrastructure/detections_repository.py
+++ b/src/core/light_curve/infrastructure/detections_repository.py
@@ -11,7 +11,10 @@ class DetectionRepository(MongoRepository):
         return self._find_all(models.Detection, payload)
 
     def _wrap_results(self, result):
-        detections = list(result)
+        try:
+            detections = list(result)
+        except TypeError:  # Pagination is being used
+            detections = result.items
         if len(detections):
             return Success(detections)
         return Failure(ClientErrorException(EmptyQuery()))

--- a/src/core/light_curve/infrastructure/non_detections_repository.py
+++ b/src/core/light_curve/infrastructure/non_detections_repository.py
@@ -11,7 +11,10 @@ class NonDetectionRepository(MongoRepository):
         return self._find_all(models.NonDetection, payload)
 
     def _wrap_results(self, result):
-        non_detections = list(result)
+        try:
+            non_detections = list(result)
+        except TypeError:  # Pagination is being used
+            non_detections = result.items
         if len(non_detections):
             return Success(non_detections)
         return Failure(ClientErrorException(EmptyQuery()))

--- a/src/shared/utils/queries.py
+++ b/src/shared/utils/queries.py
@@ -196,7 +196,7 @@ class MongoPayload(abc.ABC):
         """list[tuple] or None: Value for sorting, e.g., `[('a', 1)]`"""
         try:
             keys = self.raw_sort.get(self.sort_map["key"])
-            directions = self.raw_sort.get(self.sort_map["direction"], 1)
+            directions = self.raw_sort.get(self.sort_map["direction"])
         except AttributeError:
             return None
         return (

--- a/src/shared/utils/queries.py
+++ b/src/shared/utils/queries.py
@@ -196,7 +196,7 @@ class MongoPayload(abc.ABC):
         """list[tuple] or None: Value for sorting, e.g., `[('a', 1)]`"""
         try:
             keys = self.raw_sort.get(self.sort_map["key"])
-            directions = self.raw_sort.get(self.sort_map["direction"])
+            directions = self.raw_sort.get(self.sort_map["direction"], 1)
         except AttributeError:
             return None
         return (
@@ -207,7 +207,7 @@ class MongoPayload(abc.ABC):
                     self.Helpers.list_of_str(directions),
                 )
             ]
-            if None not in [keys, directions]
+            if keys is not None
             else None
         )
 

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -69,40 +69,6 @@ def test_get_detections(client):
     assert rv.status_code == 200
 
 
-def test_get_detection_in_date_range(client, app):
-    det = mongo_models.Detection(
-            tid="ZTF02",
-            aid="AID_ZTF2",
-            oid="ZTF22",
-            candid="candid",
-            mjd=0,
-            fid=1,
-            ra=1,
-            dec=1,
-            rb=1,
-            mag=1,
-            e_mag=1,
-            rfid=1,
-            e_ra=1,
-            e_dec=1,
-            isdiffpos=1,
-            magpsf_corr=1,
-            sigmapsf_corr=1,
-            sigmapsf_corr_ext=1,
-            corrected=True,
-            dubious=True,
-            parent_candid=1234,
-            has_stamp=True,
-            step_id_corr="step_id_corr",
-            rbversion="rbversion",
-        )
-    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
-    rv = client.get("objects/AID_ZTF2/detections?mjd=0&mjd=0")
-    assert rv.status_code == 200
-    assert len(rv.json) == 1
-    assert rv.json[0]["oid"] == "ZTF22"
-
-
 def test_sort_detections_by_date_descending(client, app):
     det = mongo_models.Detection(
             tid="ZTF02",
@@ -205,23 +171,6 @@ def test_paginated_detections_result(client, app):
     assert rv.status_code == 200
     assert len(rv.json) == 1
     assert rv.json[0]["oid"] == "ZTF22"
-
-
-def test_get_non_detection_in_date_range(client, app):
-    det = mongo_models.NonDetection(
-            tid="ZTF02",
-            aid="AID_ZTF2",
-            oid="ZTF22",
-            mjd=0,
-            diffmaglim=1,
-            fid=1,
-        )
-    app.container.mongo_db().query().get_or_create(det, model=mongo_models.NonDetection)
-    rv = client.get("objects/AID_ZTF2/non_detections?mjd=0&mjd=0")
-    assert rv.status_code == 200
-    assert len(rv.json) == 1
-    print(rv.json)
-    assert rv.json[0]["mjd"] == 0
 
 
 def test_sort_non_detections_by_date_ascending(client, app):

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -138,7 +138,41 @@ def test_sort_detections_by_date_ascending(client, app):
     assert rv.json[1]["oid"] == "ZTF2"
 
 
-def test_sort_detections_by_date_ascending(client, app):
+def test_paginated_result(client, app):
+    det = mongo_models.Detection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            candid="candid",
+            mjd=0,
+            fid=1,
+            ra=1,
+            dec=1,
+            rb=1,
+            mag=1,
+            e_mag=1,
+            rfid=1,
+            e_ra=1,
+            e_dec=1,
+            isdiffpos=1,
+            magpsf_corr=1,
+            sigmapsf_corr=1,
+            sigmapsf_corr_ext=1,
+            corrected=True,
+            dubious=True,
+            parent_candid=1234,
+            has_stamp=True,
+            step_id_corr="step_id_corr",
+            rbversion="rbversion",
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
+    rv = client.get("objects/AID_ZTF2/detections?order_by=mjd&order_mode=ASC&page_size=1")
+    assert rv.status_code == 200
+    assert len(rv.json) == 1
+    assert rv.json[0]["oid"] == "ZTF22"
+
+
+def test_sort_detections_by_date_descending(client, app):
     det = mongo_models.Detection(
             tid="ZTF02",
             aid="AID_ZTF2",

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -1,5 +1,6 @@
 import jwt
 from datetime import datetime, timedelta, timezone
+from conftest import mongo_models
 
 
 def create_token(permisions, filters, secret_key):
@@ -66,6 +67,40 @@ def test_get_detections(client):
 
     rv = client.get("objects/AID_ATLAS1/detections?survey_id=atlas")
     assert rv.status_code == 200
+
+
+def test_get_detection_in_date_range(client, app):
+    det = mongo_models.Detection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            candid="candid",
+            mjd=0,
+            fid=1,
+            ra=1,
+            dec=1,
+            rb=1,
+            mag=1,
+            e_mag=1,
+            rfid=1,
+            e_ra=1,
+            e_dec=1,
+            isdiffpos=1,
+            magpsf_corr=1,
+            sigmapsf_corr=1,
+            sigmapsf_corr_ext=1,
+            corrected=True,
+            dubious=True,
+            parent_candid=1234,
+            has_stamp=True,
+            step_id_corr="step_id_corr",
+            rbversion="rbversion",
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
+    rv = client.get("objects/AID_ZTF2/detections?mjd=0&mjd=0")
+    assert rv.status_code == 200
+    assert len(rv.json) == 1
+    assert rv.json[0]["oid"] == "ZTF22"
 
 
 def test_get_detections_not_found(client):

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -103,6 +103,76 @@ def test_get_detection_in_date_range(client, app):
     assert rv.json[0]["oid"] == "ZTF22"
 
 
+def test_sort_detections_by_date_ascending(client, app):
+    det = mongo_models.Detection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            candid="candid",
+            mjd=0,
+            fid=1,
+            ra=1,
+            dec=1,
+            rb=1,
+            mag=1,
+            e_mag=1,
+            rfid=1,
+            e_ra=1,
+            e_dec=1,
+            isdiffpos=1,
+            magpsf_corr=1,
+            sigmapsf_corr=1,
+            sigmapsf_corr_ext=1,
+            corrected=True,
+            dubious=True,
+            parent_candid=1234,
+            has_stamp=True,
+            step_id_corr="step_id_corr",
+            rbversion="rbversion",
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
+    rv = client.get("objects/AID_ZTF2/detections?order_by=mjd&order_mode=ASC")
+    assert rv.status_code == 200
+    assert len(rv.json) == 2
+    assert rv.json[0]["oid"] == "ZTF22"
+    assert rv.json[1]["oid"] == "ZTF2"
+
+
+def test_sort_detections_by_date_ascending(client, app):
+    det = mongo_models.Detection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            candid="candid",
+            mjd=0,
+            fid=1,
+            ra=1,
+            dec=1,
+            rb=1,
+            mag=1,
+            e_mag=1,
+            rfid=1,
+            e_ra=1,
+            e_dec=1,
+            isdiffpos=1,
+            magpsf_corr=1,
+            sigmapsf_corr=1,
+            sigmapsf_corr_ext=1,
+            corrected=True,
+            dubious=True,
+            parent_candid=1234,
+            has_stamp=True,
+            step_id_corr="step_id_corr",
+            rbversion="rbversion",
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
+    rv = client.get("objects/AID_ZTF2/detections?order_by=mjd&order_mode=DESC")
+    assert rv.status_code == 200
+    assert len(rv.json) == 2
+    assert rv.json[1]["oid"] == "ZTF22"
+    assert rv.json[0]["oid"] == "ZTF2"
+
+
 def test_get_detections_not_found(client):
     rv = client.get("objects/AID_ZTF3/detections?survey_id=ztf")
     assert rv.status_code == 404

--- a/tests/test_lightcurve.py
+++ b/tests/test_lightcurve.py
@@ -103,6 +103,41 @@ def test_get_detection_in_date_range(client, app):
     assert rv.json[0]["oid"] == "ZTF22"
 
 
+def test_sort_detections_by_date_descending(client, app):
+    det = mongo_models.Detection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            candid="candid",
+            mjd=0,
+            fid=1,
+            ra=1,
+            dec=1,
+            rb=1,
+            mag=1,
+            e_mag=1,
+            rfid=1,
+            e_ra=1,
+            e_dec=1,
+            isdiffpos=1,
+            magpsf_corr=1,
+            sigmapsf_corr=1,
+            sigmapsf_corr_ext=1,
+            corrected=True,
+            dubious=True,
+            parent_candid=1234,
+            has_stamp=True,
+            step_id_corr="step_id_corr",
+            rbversion="rbversion",
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
+    rv = client.get("objects/AID_ZTF2/detections?order_by=mjd&order_mode=DESC")
+    assert rv.status_code == 200
+    assert len(rv.json) == 2
+    assert rv.json[1]["oid"] == "ZTF22"
+    assert rv.json[0]["oid"] == "ZTF2"
+
+
 def test_sort_detections_by_date_ascending(client, app):
     det = mongo_models.Detection(
             tid="ZTF02",
@@ -138,7 +173,7 @@ def test_sort_detections_by_date_ascending(client, app):
     assert rv.json[1]["oid"] == "ZTF2"
 
 
-def test_paginated_result(client, app):
+def test_paginated_detections_result(client, app):
     det = mongo_models.Detection(
             tid="ZTF02",
             aid="AID_ZTF2",
@@ -172,39 +207,71 @@ def test_paginated_result(client, app):
     assert rv.json[0]["oid"] == "ZTF22"
 
 
-def test_sort_detections_by_date_descending(client, app):
-    det = mongo_models.Detection(
+def test_get_non_detection_in_date_range(client, app):
+    det = mongo_models.NonDetection(
             tid="ZTF02",
             aid="AID_ZTF2",
             oid="ZTF22",
-            candid="candid",
             mjd=0,
+            diffmaglim=1,
             fid=1,
-            ra=1,
-            dec=1,
-            rb=1,
-            mag=1,
-            e_mag=1,
-            rfid=1,
-            e_ra=1,
-            e_dec=1,
-            isdiffpos=1,
-            magpsf_corr=1,
-            sigmapsf_corr=1,
-            sigmapsf_corr_ext=1,
-            corrected=True,
-            dubious=True,
-            parent_candid=1234,
-            has_stamp=True,
-            step_id_corr="step_id_corr",
-            rbversion="rbversion",
         )
-    app.container.mongo_db().query().get_or_create(det, model=mongo_models.Detection)
-    rv = client.get("objects/AID_ZTF2/detections?order_by=mjd&order_mode=DESC")
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.NonDetection)
+    rv = client.get("objects/AID_ZTF2/non_detections?mjd=0&mjd=0")
+    assert rv.status_code == 200
+    assert len(rv.json) == 1
+    print(rv.json)
+    assert rv.json[0]["mjd"] == 0
+
+
+def test_sort_non_detections_by_date_ascending(client, app):
+    det = mongo_models.NonDetection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            mjd=0,
+            diffmaglim=1,
+            fid=1,
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.NonDetection)
+    rv = client.get("objects/AID_ZTF2/non_detections?order_by=mjd&order_mode=ASC")
     assert rv.status_code == 200
     assert len(rv.json) == 2
-    assert rv.json[1]["oid"] == "ZTF22"
-    assert rv.json[0]["oid"] == "ZTF2"
+    assert rv.json[0]["mjd"] == 0
+    assert rv.json[1]["mjd"] == 1
+
+
+def test_sort_non_detections_by_date_descending(client, app):
+    det = mongo_models.NonDetection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            mjd=0,
+            diffmaglim=1,
+            fid=1,
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.NonDetection)
+    rv = client.get("objects/AID_ZTF2/non_detections?order_by=mjd&order_mode=DESC")
+    assert rv.status_code == 200
+    assert len(rv.json) == 2
+    assert rv.json[1]["mjd"] == 0
+    assert rv.json[0]["mjd"] == 1
+
+
+def test_paginated_non_detections_result(client, app):
+    det = mongo_models.NonDetection(
+            tid="ZTF02",
+            aid="AID_ZTF2",
+            oid="ZTF22",
+            mjd=0,
+            diffmaglim=1,
+            fid=1,
+        )
+    app.container.mongo_db().query().get_or_create(det, model=mongo_models.NonDetection)
+    rv = client.get("objects/AID_ZTF2/non_detections?order_by=mjd&order_mode=ASC&page_size=1")
+    assert rv.status_code == 200
+    assert len(rv.json) == 1
+    assert rv.json[0]["mjd"] == 0
 
 
 def test_get_detections_not_found(client):


### PR DESCRIPTION
Uses sorting and "pagination" to allow a limited number of detections or non-detections to be returned. This only affects the detections and non_detections endpoints, it is not available for the lightcurve itself.

The pagination is in quotation since it will not return a Pagination object. It will only return the (non)detections that are in the corresponding page.

The use to get only the first detection (as list):

``objects/<aid>/detections?order_by=mjd&order_mode=ASC&page_size=1``