### PR TITLE
Added compatibility to use mongo for ZTF queries.

### DIFF
--- a/lightcurve/src/core/models.py
+++ b/lightcurve/src/core/models.py
@@ -26,6 +26,11 @@ class Detection(BaseModel):
     has_stamp: bool
     extra_fields: Optional[dict] = {}
 
+    def __hash__(self):
+        return hash(str(self.candid))
+    def __eq__(self, other):
+        return str(self.candid)==str(other.candid)
+
 
 class NonDetection(BaseModel):
     aid: Optional[str] = None
@@ -35,3 +40,9 @@ class NonDetection(BaseModel):
     mjd: float
     fid: int
     diffmaglim: Optional[float] = None
+
+    def __hash__(self):
+        return hash((self.oid, self.fid, self.mjd))
+    def __eq__(self, other):
+        return (self.oid, self.fid, self.mjd) ==\
+                (other.oid, other.fid, other.mjd)

--- a/lightcurve/src/core/models.py
+++ b/lightcurve/src/core/models.py
@@ -28,8 +28,9 @@ class Detection(BaseModel):
 
     def __hash__(self):
         return hash(str(self.candid))
+
     def __eq__(self, other):
-        return str(self.candid)==str(other.candid)
+        return str(self.candid) == str(other.candid)
 
 
 class NonDetection(BaseModel):
@@ -43,6 +44,10 @@ class NonDetection(BaseModel):
 
     def __hash__(self):
         return hash((self.oid, self.fid, self.mjd))
+
     def __eq__(self, other):
-        return (self.oid, self.fid, self.mjd) ==\
-                (other.oid, other.fid, other.mjd)
+        return (self.oid, self.fid, self.mjd) == (
+            other.oid,
+            other.fid,
+            other.mjd,
+        )

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -87,11 +87,11 @@ def _get_all_unique_detections(
     try:
         sql_detections = _get_detections_sql(session_factory, oid, tid=survey_id)
         mongo_detections = _get_detections_mongo(mongo_db, oid, tid=survey_id)
-
-        detections = list(set(sql_detections + mongo_detections))
-        return Success(detections)
-    except Exception as e:
+    except (DatabaseError, ObjectNotFound) as e:
         return Failure(e)
+
+    detections = list(set(sql_detections + mongo_detections))
+    return Success(detections)
 
 def get_non_detections(
     oid: str,
@@ -127,7 +127,7 @@ def _get_all_unique_non_detections(
 
         non_detections = list(set(sql_non_detections + mongo_non_detections))
         return Success(non_detections)
-    except Exception as e:
+    except (DatabaseError, ObjectNotFound) as e:
         return Failure(e)
 
 

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -40,6 +40,25 @@ def get_lightcurve(
     handle_success: Callable[..., dict] = default_handle_success,
     handle_error: Callable[Exception, None] = default_handle_error,
 ) -> dict:
+    """Retrieves both unique detections and non detections for a given object in
+    a given survey.
+
+    :param oid: oid for the object.
+    :type oid: str
+    :param survey_id: id for the survey, can be "ztf" or "atlas"
+    :type survey_id: str
+    :param session_factory: Session factory for SQL requests.
+    :type session_factory: Callable[..., AbstractContextManager[Session]]
+    :param mongo_db: Mongo database for mongo requests.
+    :type mongo_db: Database
+    :param handle_success: Callback for handling a success.
+    :type handle_success: Callable[..., dict]
+    :param handle_error: Callback for handling failure.
+    :type handle_error: Callable[Exception, None]
+    :return: The result of calling handle_success with a dictionary
+    containing all detections and non_detections with removed duplicates.
+    :rtype: dict
+    """
     if survey_id in ["ztf", "atlas"]:
         detections = _get_all_unique_detections(
             oid, survey_id, session_factory=session_factory, mongo_db=mongo_db
@@ -68,7 +87,26 @@ def get_detections(
     mongo_db: Database = None,
     handle_success: Callable[..., dict] = default_handle_success,
     handle_error: Callable[Exception, None] = default_handle_error,
-) -> list:
+) -> dict:
+    """Retrieves all unique detections from the databases for a given
+    object in a given survey.
+
+    :param oid: oid for the object.
+    :type oid: str
+    :param survey_id: id for the survey, can be "ztf" or "atlas"
+    :type survey_id: str
+    :param session_factory: Session factory for SQL requests.
+    :type session_factory: Callable[..., AbstractContextManager[Session]]
+    :param mongo_db: Mongo database for mongo requests.
+    :type mongo_db: Database
+    :param handle_success: Callback for handling a success.
+    :type handle_success: Callable[..., dict]
+    :param handle_error: Callback for handling failure.
+    :type handle_error: Callable[Exception, None]
+    :return: The result of calling handle_success with a list containing
+    all unique Detection objects in the databases.
+    :rtype: dict
+    """
     if survey_id in ["ztf", "atlas"]:
         detections_result = _get_all_unique_detections(
             oid, survey_id, session_factory=session_factory, mongo_db=mongo_db
@@ -108,6 +146,25 @@ def get_non_detections(
     handle_success: Callable[..., dict] = default_handle_success,
     handle_error: Callable[Exception, None] = default_handle_error,
 ) -> list:
+    """Retrieves all unique non-detections from the databases for a given
+    object in a given survey.
+
+    :param oid: oid for the object.
+    :type oid: str
+    :param survey_id: id for the survey, can be "ztf" or "atlas"
+    :type survey_id: str
+    :param session_factory: Session factory for SQL requests.
+    :type session_factory: Callable[..., AbstractContextManager[Session]]
+    :param mongo_db: Mongo database for mongo requests.
+    :type mongo_db: Database
+    :param handle_success: Callback for handling a success.
+    :type handle_success: Callable[..., dict]
+    :param handle_error: Callback for handling failure.
+    :type handle_error: Callable[Exception, None]
+    :return: The result of calling handle_success with a list containing
+    all unique NonDetection objects in the databases.
+    :rtype: dict
+    """
     if survey_id == "ztf":
         non_detections_result = _get_all_unique_non_detections(
             oid, survey_id, session_factory=session_factory, mongo_db=mongo_db

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -31,7 +31,6 @@ def fail_from_list(failable_list: list):
         if not is_successful(el):
             return el.failure()
 
-
 def get_lightcurve(
     oid: str,
     survey_id: str,
@@ -41,10 +40,10 @@ def get_lightcurve(
     handle_error: Callable[Exception, None] = default_handle_error,
 ) -> dict:
     if survey_id == "ztf":
-        detections = _get_detections_sql(session_factory, oid)
-        non_detections = _get_non_detections_sql(session_factory, oid)
+        detections = _get_detections_sql(session_factory, oid, tid=survey_id)
+        non_detections = _get_non_detections_sql(session_factory, oid, tid=survey_id)
     elif survey_id == "atlas":
-        detections = _get_detections_mongo(mongo_db, oid)
+        detections = _get_detections_mongo(mongo_db, oid, tid="atlas")
         non_detections = Success([])
     else:
         handle_error(SurveyIdError(survey_id))
@@ -68,18 +67,22 @@ def get_detections(
     handle_success: Callable[..., dict] = default_handle_success,
     handle_error: Callable[Exception, None] = default_handle_error,
 ) -> list:
-    if survey_id == "ztf":
-        result = _get_detections_sql(session_factory, oid)
+    if survey_id in ["ztf", "atlas"]:
+        sql_detections_result = _get_detections_sql(session_factory, oid, tid=survey_id)
+        if not is_successful(sql_detections_result):
+            handle_error(sql_detections_result.failure())
+        sql_detections = sql_detections_result.unwrap()
 
-    elif survey_id == "atlas":
-        result = _get_detections_mongo(mongo_db, oid)
+        mongo_detections_result = _get_detections_mongo(mongo_db, oid, tid=survey_id)
+        if not is_successful(mongo_detections_result):
+            handle_error(mongo_detections_result.failure())
+        mongo_detections = mongo_detections_result.unwrap()
+
+        detections = sql_detections + mongo_detections
+        return handle_success(detections)
     else:
         handle_error(SurveyIdError(survey_id))
 
-    if is_successful(result):
-        return handle_success(result.unwrap())
-    else:
-        handle_error(result.failure())
 
 
 def get_non_detections(
@@ -91,11 +94,19 @@ def get_non_detections(
     handle_error: Callable[Exception, None] = default_handle_error,
 ):
     if survey_id == "ztf":
-        result = _get_non_detections_sql(session_factory, oid)
-        if is_successful(result):
-            return handle_success(result.unwrap())
-        else:
-            return handle_error(result.failure())
+        sql_non_detections_result = _get_non_detections_sql(session_factory, oid, tid=survey_id)
+        if not is_successful(sql_non_detections_result):
+            handle_error(sql_non_detections_result.failure())
+        sql_non_detections = sql_non_detections_result.unwrap()
+
+        mongo_non_detections_result = _get_non_detections_mongo(mongo_db, oid, tid=survey_id)
+        if not is_successful(mongo_non_detections_result):
+            handle_error(mongo_non_detections_result.failure())
+        mongo_non_detections = mongo_non_detections_result.unwrap()
+
+        non_detections = sql_non_detections + mongo_non_detections
+        return handle_success(non_detections)
+
     elif survey_id == "atlas":
         handle_error(AtlasNonDetectionError())
     else:
@@ -103,8 +114,11 @@ def get_non_detections(
 
 
 def _get_detections_sql(
-    session_factory: Callable[..., AbstractContextManager[Session]], oid: str
-) -> list[DetectionModel]:
+    session_factory: Callable[..., AbstractContextManager[Session]], oid: str,
+    tid: str
+) -> Success[list[DetectionModel]] | Failure:
+    if tid == "atlas":
+        return Success([])
     try:
         with session_factory() as session:
             stmt = select(Detection, text("'ztf'")).filter(
@@ -121,13 +135,13 @@ def _get_detections_sql(
 
 
 def _get_detections_mongo(
-    database: Database, oid: str
-) -> list[DetectionModel]:
+    database: Database, oid: str, tid: str
+) -> Success[list[DetectionModel]] | Failure:
     try:
         obj = database["object"].find_one({"oid": oid}, {"_id": 1})
         if obj is None:
             raise ValueError()
-        result = database["detection"].find({"aid": obj["_id"]})
+        result = database["detection"].find({"aid": obj["_id"], "tid": tid})
         result = [DetectionModel(**res, candid=res["_id"]) for res in result]
         return Success(result)
     except ValueError as e:
@@ -137,8 +151,11 @@ def _get_detections_mongo(
 
 
 def _get_non_detections_sql(
-    session_factory: Callable[..., AbstractContextManager[Session]], oid: str
-) -> list[NonDetectionModel]:
+    session_factory: Callable[..., AbstractContextManager[Session]], oid: str,
+    tid: str
+) -> Success[list[NonDetectionModel]] | Failure:
+    if tid == "atlas":
+        return Success([])
     try:
         with session_factory() as session:
             stmt = select(NonDetection, text("'ztf'")).where(
@@ -153,6 +170,22 @@ def _get_non_detections_sql(
     except Exception as e:
         return Failure(DatabaseError(e))
 
+def _get_non_detections_mongo(
+    database: Database, oid: str, tid: str
+) -> Success[list[NonDetectionModel]] | Failure:
+    if tid == "atlas":
+        return Success([])
+    try:
+        obj = database["object"].find_one({"oid": oid}, {"_id": 1})
+        if obj is None:
+            raise ValueError()
+        result = database["non_detection"].find({"aid": obj["_id"], "tid": tid})
+        result = [NonDetectionModel(**res) for res in result]
+        return Success(result)
+    except ValueError as e:
+        return Failure(ObjectNotFound(oid))
+    except Exception as e:
+        return Failure(DatabaseError(e))
 
 def _ztf_detection_to_multistream(
     detection: dict[str, any],

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -4,7 +4,7 @@ from typing import Callable, Any
 from db_plugins.db.sql.models import Detection, NonDetection
 from pymongo.database import Database
 from returns.pipeline import is_successful
-from returns.result import Failure, Success
+from returns.result import Failure, Success, Result
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
@@ -125,7 +125,7 @@ def _get_all_unique_detections(
     survey_id: str,
     session_factory: Callable[..., AbstractContextManager[Session]] = None,
     mongo_db: Database = None,
-) -> Success[list[DetectionModel]] | Failure:
+) -> Result[list[DetectionModel], BaseException]:
     try:
         sql_detections = _get_detections_sql(
             session_factory, oid, tid=survey_id
@@ -185,7 +185,7 @@ def _get_all_unique_non_detections(
     survey_id: str,
     session_factory: Callable[..., AbstractContextManager[Session]] = None,
     mongo_db: Database = None,
-) -> Success[list[NonDetectionModel]] | Failure:
+) -> Result[list[NonDetectionModel], BaseException]:
     try:
         sql_non_detections = _get_non_detections_sql(
             session_factory, oid, tid=survey_id

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -88,7 +88,7 @@ def _get_all_unique_detections(
         sql_detections = _get_detections_sql(session_factory, oid, tid=survey_id)
         mongo_detections = _get_detections_mongo(mongo_db, oid, tid=survey_id)
 
-        detections = sql_detections + mongo_detections
+        detections = list(set(sql_detections + mongo_detections))
         return Success(detections)
     except Exception as e:
         return Failure(e)
@@ -125,7 +125,7 @@ def _get_all_unique_non_detections(
         sql_non_detections = _get_non_detections_sql(session_factory, oid, tid=survey_id)
         mongo_non_detections = _get_non_detections_mongo(mongo_db, oid, tid=survey_id)
 
-        non_detections = sql_non_detections + mongo_non_detections
+        non_detections = list(set(sql_non_detections + mongo_non_detections))
         return Success(non_detections)
     except Exception as e:
         return Failure(e)
@@ -265,9 +265,11 @@ def _ztf_non_detection_to_multistream(
     :param tid: Telescope id for this detection.
     :return: A NonDetection with the converted data."""
     return NonDetectionModel(
+        aid=non_detections.get("aid", None),
         tid=tid,
+        sid=non_detections.get("sid", None),
         oid=non_detections["oid"],
         mjd=non_detections["mjd"],
         fid=non_detections["fid"],
-        diffmaglims=non_detections.get("diffmaglim", None),
+        diffmaglim=non_detections.get("diffmaglim", None),
     )

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -1,5 +1,5 @@
 from contextlib import AbstractContextManager
-from typing import Callable
+from typing import Callable, Any
 
 from db_plugins.db.sql.models import Detection, NonDetection
 from pymongo.database import Database
@@ -37,9 +37,9 @@ def get_lightcurve(
     survey_id: str,
     session_factory: Callable[..., AbstractContextManager[Session]] = None,
     mongo_db: Database = None,
-    handle_success: Callable[..., dict] = default_handle_success,
-    handle_error: Callable[Exception, None] = default_handle_error,
-) -> dict:
+    handle_success: Callable[[Any], Any] = default_handle_success,
+    handle_error: Callable[[Exception], None] = default_handle_error,
+) -> dict[str, list[DetectionModel] | list[NonDetectionModel]]:
     """Retrieves both unique detections and non detections for a given object in
     a given survey.
 
@@ -52,12 +52,12 @@ def get_lightcurve(
     :param mongo_db: Mongo database for mongo requests.
     :type mongo_db: Database
     :param handle_success: Callback for handling a success.
-    :type handle_success: Callable[..., dict]
+    :type handle_success: Callable[[Any], list]
     :param handle_error: Callback for handling failure.
-    :type handle_error: Callable[Exception, None]
+    :type handle_error: Callable[[Exception], None]
     :return: The result of calling handle_success with a dictionary
     containing all detections and non_detections with removed duplicates.
-    :rtype: dict
+    :rtype: dict[str, list[DetectionModel] | list[NonDetectionModel]]
     """
     if survey_id in ["ztf", "atlas"]:
         detections = _get_all_unique_detections(
@@ -85,9 +85,9 @@ def get_detections(
     survey_id: str,
     session_factory: Callable[..., AbstractContextManager[Session]] = None,
     mongo_db: Database = None,
-    handle_success: Callable[..., dict] = default_handle_success,
-    handle_error: Callable[Exception, None] = default_handle_error,
-) -> dict:
+    handle_success: Callable[[Any], list] = default_handle_success,
+    handle_error: Callable[[Exception], None] = default_handle_error,
+) -> list[DetectionModel]:
     """Retrieves all unique detections from the databases for a given
     object in a given survey.
 
@@ -100,12 +100,12 @@ def get_detections(
     :param mongo_db: Mongo database for mongo requests.
     :type mongo_db: Database
     :param handle_success: Callback for handling a success.
-    :type handle_success: Callable[..., dict]
+    :type handle_success: Callable[[Any], list]
     :param handle_error: Callback for handling failure.
     :type handle_error: Callable[Exception, None]
     :return: The result of calling handle_success with a list containing
     all unique Detection objects in the databases.
-    :rtype: dict
+    :rtype: list[DetectionModel]
     """
     if survey_id in ["ztf", "atlas"]:
         detections_result = _get_all_unique_detections(
@@ -143,9 +143,9 @@ def get_non_detections(
     survey_id: str,
     session_factory: Callable[..., AbstractContextManager[Session]] = None,
     mongo_db: Database = None,
-    handle_success: Callable[..., dict] = default_handle_success,
-    handle_error: Callable[Exception, None] = default_handle_error,
-) -> list:
+    handle_success: Callable[[Any], list] = default_handle_success,
+    handle_error: Callable[[Exception], None] = default_handle_error,
+) -> list[NonDetectionModel]:
     """Retrieves all unique non-detections from the databases for a given
     object in a given survey.
 
@@ -158,12 +158,12 @@ def get_non_detections(
     :param mongo_db: Mongo database for mongo requests.
     :type mongo_db: Database
     :param handle_success: Callback for handling a success.
-    :type handle_success: Callable[..., dict]
+    :type handle_success: Callable[[Any], list]
     :param handle_error: Callback for handling failure.
-    :type handle_error: Callable[Exception, None]
+    :type handle_error: Callable[[Exception], None]
     :return: The result of calling handle_success with a list containing
     all unique NonDetection objects in the databases.
-    :rtype: dict
+    :rtype: list[NonDetectionModel]
     """
     if survey_id == "ztf":
         non_detections_result = _get_all_unique_non_detections(

--- a/lightcurve/tests/conftest.py
+++ b/lightcurve/tests/conftest.py
@@ -220,14 +220,20 @@ def populate_mongo(database: MongoConnection):
     database.create_db()
     add_mongo_objects(database.database)
     add_mongo_detections(database.database)
+    add_mongo_non_detections(database.database)
 
 
 def add_mongo_objects(database: Database):
     object1 = {
         "_id": "aid1",
-        "oid": ["oid1", "oid2"],
+        "oid": ["oid2", "oid3"],
+    }
+    object2 = {
+        "_id": "aid3",
+        "oid": ["oid1"],
     }
     database["object"].insert_one(object1)
+    database["object"].insert_one(object2)
 
 
 def add_mongo_detections(database: Database):
@@ -235,7 +241,7 @@ def add_mongo_detections(database: Database):
         {
             "_id": "candid1",
             "aid": "aid1",
-            "oid": "oid1",
+            "oid": "oid2",
             "tid": "atlas",
             "mjd": 59000,
             "fid": 1,
@@ -251,8 +257,8 @@ def add_mongo_detections(database: Database):
         {
             "_id": "candid2",
             "aid": "aid1",
+            "oid": "oid2",
             "tid": "atlas",
-            "oid": "oid1",
             "mjd": 59001,
             "fid": 2,
             "ra": 11,
@@ -268,7 +274,7 @@ def add_mongo_detections(database: Database):
             "_id": "candid3",
             "aid": "aid2",
             "tid": "atlas",
-            "oid": "oid2",
+            "oid": "oid3",
             "mjd": 59005,
             "fid": 3,
             "ra": 12.0,
@@ -286,7 +292,7 @@ def add_mongo_detections(database: Database):
             "_id": "candid4",
             "aid": "aid2",
             "tid": "atlas",
-            "oid": "oid2",
+            "oid": "oid3",
             "mjd": 59006,
             "fid": 3,
             "ra": 11.0,
@@ -300,9 +306,83 @@ def add_mongo_detections(database: Database):
             "dubious": False,
             "has_stamp": False,
         },
+        {
+            "_id": "candid5",
+            "aid": "aid2",
+            "tid": "atlas",
+            "oid": "oid3",
+            "mjd": 59006,
+            "fid": 3,
+            "ra": 11.0,
+            "e_ra": 0.2,
+            "dec": 23.0,
+            "e_dec": 0.3,
+            "mag": 12.0,
+            "e_mag": 0.4,
+            "isdiffpos": 1,
+            "corrected": False,
+            "dubious": False,
+            "has_stamp": False,
+        },
+        {
+            "_id": "candid6",
+            "tid": "ztf",
+            "aid": "aid3",
+            "oid": "oid1",
+            "mjd": 59010,
+            "fid": 1,
+            "ra": 10.0,
+            "e_ra": 0.1,
+            "dec": 20.0,
+            "e_dec": 0.1,
+            "mag": 15.0,
+            "e_mag": 0.1,
+            "isdiffpos": 1,
+            "corrected": False,
+            "dubious": False,
+            "has_stamp": False,
+        }, # Unique ZTF detection
+        {
+            "_id": "123",
+            "tid": "ztf",
+            "aid": "aid3",
+            "oid": "oid1",
+            "mjd": 59000,
+            "fid": 1,
+            "ra": 10,
+            "dec": 20,
+            "mag": 15,
+            "e_mag": 0.5,
+            "isdiffpos": 1,
+            "corrected": False,
+            "dubious": False,
+            "has_stamp": False,
+        }, # Duplicated ZTF detection
     ]
     for det in detections:
         database.detection.insert_one(det)
+
+def add_mongo_non_detections(database: Database):
+    non_detections = [
+        {
+            "tid": "ztf",
+            "aid": "aid3",
+            "oid": "oid1",
+            "mjd": 59000,
+            "fid": 1,
+            "diffmaglim": 0.5
+        }, #duplicate
+        {
+            "tid": "ztf",
+            "aid": "aid3",
+            "oid": "oid1",
+            "mjd": 59015,
+            "fid": 1,
+            "diffmaglim": 0.6
+        }, # unique ztf non detection
+    ]
+    for non_det in non_detections:
+        database.non_detection.insert_one(non_det)
 
 
 def teardown_mongo(database: MongoConnection):

--- a/lightcurve/tests/test_api.py
+++ b/lightcurve/tests/test_api.py
@@ -4,20 +4,27 @@ def test_root(test_client):
 
 
 def test_detections_without_survey_id_param(
-    psql_service, init_psql, test_client
+    psql_service, init_psql, test_client,
+    mongo_service, init_mongo,
 ):
     res = test_client.get("/detections/oid1")
     assert res.status_code == 200
     assert len(res.json()) == 3
 
 
-def test_detections_from_ztf(psql_service, init_psql, test_client):
+def test_detections_from_ztf(
+        psql_service, init_psql, test_client,
+        mongo_service, init_mongo,
+    ):
     res = test_client.get("/detections/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     assert len(res.json()) == 3
 
 
-def test_non_detections_from_ztf(psql_service, init_psql, test_client):
+def test_non_detections_from_ztf(
+        psql_service, init_psql, test_client,
+        mongo_service, init_mongo,
+    ):
     res = test_client.get("/non_detections/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     assert len(res.json()) == 3
@@ -51,7 +58,10 @@ def test_lightcurve_from_atlas_without_results(
     assert res.status_code == 404
 
 
-def test_lightcurve_from_ztf(psql_service, init_psql, test_client):
+def test_lightcurve_from_ztf(
+        psql_service, init_psql, test_client,
+        mongo_service, init_mongo,
+    ):
     res = test_client.get("/lightcurve/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     json_res = res.json()

--- a/lightcurve/tests/test_api.py
+++ b/lightcurve/tests/test_api.py
@@ -8,19 +8,19 @@ def test_detections_without_survey_id_param(
 ):
     res = test_client.get("/detections/oid1")
     assert res.status_code == 200
-    assert len(res.json()) == 2
+    assert len(res.json()) == 3
 
 
 def test_detections_from_ztf(psql_service, init_psql, test_client):
     res = test_client.get("/detections/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
-    assert len(res.json()) == 2
+    assert len(res.json()) == 3
 
 
 def test_non_detections_from_ztf(psql_service, init_psql, test_client):
     res = test_client.get("/non_detections/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
-    assert len(res.json()) == 2
+    assert len(res.json()) == 3
 
 
 def test_detections_from_atlas(mongo_service, init_mongo, test_client):
@@ -55,8 +55,8 @@ def test_lightcurve_from_ztf(psql_service, init_psql, test_client):
     res = test_client.get("/lightcurve/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     json_res = res.json()
-    assert len(json_res["detections"]) == 2
-    assert len(json_res["non_detections"]) == 2
+    assert len(json_res["detections"]) == 3
+    assert len(json_res["non_detections"]) == 3
 
 
 def test_has_metrics(test_client):

--- a/lightcurve/tests/test_service.py
+++ b/lightcurve/tests/test_service.py
@@ -98,8 +98,8 @@ def test_get_ztf_lightcurve(
         mongo_db=mongo_database,
     )
     assert isinstance(result, dict)
-    assert len(result["detections"]) == 2
-    assert len(result["non_detections"]) == 2
+    assert len(result["detections"]) == 3
+    assert len(result["non_detections"]) == 3
 
 
 def test_get_atlas_lightcurve(mongo_service, mongo_database, init_mongo):

--- a/lightcurve/tests/test_service.py
+++ b/lightcurve/tests/test_service.py
@@ -7,45 +7,59 @@ from core.models import (
 import pytest
 
 
-def test_get_ztf_detections(psql_service, psql_session, init_psql):
+def test_get_ztf_detections(
+    psql_service, psql_session, init_psql,
+    mongo_service, mongo_database, init_mongo
+):
     result = get_detections(
         session_factory=psql_session,
+        mongo_db=mongo_database,
         oid="oid1",
         survey_id="ztf",
     )
-    assert len(result) == 2
+    assert len(result) == 3
     assert type(result[0]) is DetectionModel
 
 
 def test_get_detections_from_unknown_survey(
-    psql_service, psql_session, init_psql
+    psql_service, psql_session, init_psql,
+    mongo_service, mongo_database, init_mongo
 ):
     with pytest.raises(
         SurveyIdError, match="survey id not recognized unknown"
     ):
         get_detections(
             session_factory=psql_session,
+        mongo_db=mongo_database,
             oid="oid1",
             survey_id="unknown",
         )
 
 
-def test_get_ztf_non_detections(psql_service, psql_session, init_psql):
+def test_get_ztf_non_detections(
+    psql_service, psql_session, init_psql,
+    mongo_service, mongo_database, init_mongo
+):
     result = get_non_detections(
-        session_factory=psql_session, oid="oid1", survey_id="ztf"
+        session_factory=psql_session,
+        mongo_db=mongo_database,
+        oid="oid1",
+        survey_id="ztf"
     )
-    assert len(result) == 2
+    assert len(result) == 3
     assert type(result[0]) is NonDetectionModel
 
 
 def test_get_non_detections_from_unknown_survey(
-    psql_service, psql_session, init_psql
+    psql_service, psql_session, init_psql,
+    mongo_service, mongo_database, init_mongo
 ):
     with pytest.raises(
         SurveyIdError, match="survey id not recognized unknown"
     ):
         get_non_detections(
             session_factory=psql_session,
+            mongo_db=mongo_database,
             oid="oid1",
             survey_id="unknown",
         )
@@ -53,7 +67,7 @@ def test_get_non_detections_from_unknown_survey(
 
 def test_get_atlas_detections(mongo_service, mongo_database, init_mongo):
     result = get_detections(
-        oid="oid1",
+        oid="oid2",
         survey_id="atlas",
         mongo_db=mongo_database,
     )
@@ -67,15 +81,21 @@ def test_get_atlas_non_detections(mongo_service, mongo_database, init_mongo):
         match="Can't retrieve non detections: ATLAS does not provide non_detections",
     ):
         get_non_detections(
-            oid="oid1",
+            oid="oid2",
             survey_id="atlas",
             mongo_db=mongo_database,
         )
 
 
-def test_get_ztf_lightcurve(psql_service, psql_session, init_psql):
+def test_get_ztf_lightcurve(
+    psql_service, psql_session, init_psql,
+    mongo_service, mongo_database, init_mongo
+):
     result = get_lightcurve(
-        oid="oid1", survey_id="ztf", session_factory=psql_session
+        oid="oid1",
+        survey_id="ztf",
+        session_factory=psql_session,
+        mongo_db=mongo_database,
     )
     assert isinstance(result, dict)
     assert len(result["detections"]) == 2
@@ -84,7 +104,7 @@ def test_get_ztf_lightcurve(psql_service, psql_session, init_psql):
 
 def test_get_atlas_lightcurve(mongo_service, mongo_database, init_mongo):
     result = get_lightcurve(
-        oid="oid1", survey_id="atlas", mongo_db=mongo_database
+        oid="oid2", survey_id="atlas", mongo_db=mongo_database
     )
     assert isinstance(result, dict)
     assert len(result["detections"]) == 2


### PR DESCRIPTION
Closes #184 

## Summary of the changes
Added compatibility to use mongo for ZTF queries.
Slight restructuring of get_detection/get_non_detections/get_lightcurve functions was needed.
Added new argument for _get_detections_* and _get_non_detections_*, tid, to specify a telescope, returning an empty success message when not applicable. . Also added get_non_detections_mongo.
Updated some expected return types.
Added new intermediary functions _get_all_unique_(detections/non_detections). Since the task of retrieving all detections/non_detections is done on the get_lightcurve and get_detections functions, the code was refactored into those intermediary functions.
To simplify error handling, functions that query the database no longer return Success or Failure, as this is now done by the new intermediate functions. They now rise errors instead of returning a Failure state. The intermediate functions catch them and return Success or Failure accordingly.

## If the change is BREAKING, please give more details about the breaking changes

Queries for ZTF will now return data that is also on mongo.

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.
