### PR TITLE
Use of CalVer YY.MM.micro-modifier for package versioning

### DIFF
--- a/ci/build/build_staging.py
+++ b/ci/build/build_staging.py
@@ -1,5 +1,5 @@
 import anyio
-from utils import build, get_tags, update_version, git_push, update_chart
+from build.utils import build, get_tags, update_version, git_push, update_chart
 from multiprocessing import Process
 
 

--- a/ci/build/calver.py
+++ b/ci/build/calver.py
@@ -1,0 +1,43 @@
+import datetime
+
+
+def get_micro_from_dash(micro_and_modifier: str):
+    micro = micro_and_modifier.split("-")[0]
+    try:
+        modifier = micro_and_modifier.split("-")[1]
+    except IndexError:
+        modifier = ""
+    return micro, modifier
+
+
+def get_micro_from_a(micro_and_modifier: str):
+    micro = micro_and_modifier.split("a")[0]
+    try:
+        modifier = micro_and_modifier.split("a")[1]
+    except IndexError:
+        modifier = ""
+    return micro, modifier
+
+
+def get_calver(current_version: str, version_from_command: str):
+    major = str(datetime.datetime.now().year)[2:]
+    minor = datetime.datetime.now().month
+    micro_and_modifier = current_version.split(".")[2]
+    if "-" in micro_and_modifier:
+        micro, modifier = get_micro_from_dash(micro_and_modifier)
+    elif "a" in micro_and_modifier:
+        micro, modifier = get_micro_from_a(micro_and_modifier)
+    elif micro_and_modifier.isdigit():
+        micro = micro_and_modifier
+        modifier = ""
+    else:
+        raise ValueError("Could not parse micro and modifier")
+    if version_from_command == "prerelease":
+        try:
+            modifier = f"-rc{int(modifier[2:]) + 1}"
+        except ValueError:
+            modifier = "-rc1"
+    else:
+        modifier = ""
+        micro = int(micro) + 1
+    return f"{major}.{minor}.{micro}{modifier}"

--- a/ci/build/chart_script.py
+++ b/ci/build/chart_script.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from calver import get_calver as _get_calver
 
 
 def update_app_version(package: str, new_version: str, dry_run: bool):
@@ -27,14 +28,18 @@ def update_chart_version(
         if not match:
             raise ValueError("Could not find valid version in Chart.yaml")
         version = version or match.group("version")
-        major, minor, patch = version.split(".")
+        new_version = _get_calver(version, "chart_update")
+        major, minor, patch = new_version.split(".")
         chart = re.sub(
             r"version: (\d+).(\d+).(\d+.*)",
-            f"version: { major }.{ minor }.{ int(patch) + 1 }",
+            f"version: { major }.{ minor }.{ patch }",
             original,
         )
         if not dry_run:
             f.write(chart)
+        else:
+            print("Dry run, not writing to file")
+            print(f"Would update {package} to version:", new_version)
 
 
 def get_package_version(package: str):

--- a/ci/build/utils.py
+++ b/ci/build/utils.py
@@ -150,7 +150,13 @@ async def update_chart(chart_name: str, dry_run: bool):
     async with dagger.Connection(config) as client:
         path = pathlib.Path().cwd().parent.absolute()
 
-        script = ["poetry", "run", "python", "chart_script.py", chart_name]
+        script = [
+            "poetry",
+            "run",
+            "python",
+            "build/chart_script.py",
+            chart_name,
+        ]
         if dry_run:
             script.append("--dry-run")
         await (

--- a/ci/build/utils.py
+++ b/ci/build/utils.py
@@ -2,6 +2,7 @@ import sys
 import dagger
 import os
 import pathlib
+from build.calver import get_calver as _get_calver
 
 
 def _get_publish_secret(client):
@@ -84,7 +85,13 @@ async def update_version(package_dir: str, version: str, dry_run: bool):
                 ),
             )
         )
-        update_version_command = ["poetry", "version", version]
+        current_version = await (
+            source.with_workdir(f"/web-services/{package_dir}")
+            .with_exec(["poetry", "version", "--short"])
+            .stdout()
+        )
+        new_version = _get_calver(current_version, version)
+        update_version_command = ["poetry", "version", new_version]
         if dry_run:
             update_version_command.append("--dry-run")
 


### PR DESCRIPTION
## Summary of the changes
Added a CalVer parser for the update version step of the CI pipeline.

## Observations
Current packages with SemVer will be converted to CalVer.
Current modifier of `{major}.{minor}.{patch}aN` will be replaced by `-rcN`

Chart version does not follow CalVer (yet). Might open another PR for that.

UPDATE: Chart version also follows CalVer

## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.