### PR TITLE
Chore: Add envrioment variable to lightcurve chart

### DIFF
--- a/charts/lightcurve/templates/configmap.yaml
+++ b/charts/lightcurve/templates/configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Values.namespace }}
 data:
   port: '{{ .Values.configmap.port }}'
+  api-url: '{{ .Values.configmap.apiUrl }}'
 ---
 apiVersion: v1
 metadata:

--- a/charts/lightcurve/templates/deployment.yaml
+++ b/charts/lightcurve/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "lightcurve.fullname" . }}
                   key: port
+            - name: STATIC_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "lightcurve.fullname" . }}
+                  key: api-url
             - name: PSQL_HOST
               valueFrom:
                 secretKeyRef:

--- a/charts/lightcurve/values.yaml
+++ b/charts/lightcurve/values.yaml
@@ -44,6 +44,7 @@ affinity:
 
 configmap:
   port: ""
+  apiUrl: ""
 
 ingress:
   certificateArn: ""


### PR DESCRIPTION
## Summary of the changes

Added a `API_URL` env variable to use on the ligthcurve api. This variable is needed to access the static files (JS and CSS) from the client using the htmx endpoint.