### PR TITLE
Fix: Lightcurve statice route error and mongo authentication error

### DIFF
--- a/charts/lightcurve/templates/deployment.yaml
+++ b/charts/lightcurve/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
                 secretKeyRef:
                   name: database-auth
                   key: mongo-database
+            - name: MONGO_AUTH_SOURCE
+              valueFrom:
+                secretKeyRef:
+                  name: database-auth
+                  key: mongo-auth-source
             - name: MONGO_USER
               valueFrom:
                 secretKeyRef:

--- a/charts/lightcurve/values.yaml
+++ b/charts/lightcurve/values.yaml
@@ -63,6 +63,7 @@ secrets:
   mongo:
     host: ""
     database: ""
+    auth-source: ""
     user: ""
     password: ""
     port: ""    

--- a/libs/ralidator-fastapi/ralidator_fastapi/ralidator_fastapi.py
+++ b/libs/ralidator-fastapi/ralidator_fastapi/ralidator_fastapi.py
@@ -1,19 +1,25 @@
+import re
+
 from ralidator_core.ralidator_core import (
     Ralidator,
     RalidatorCoreSettingsFactory,
 )
 from ralidator_core.settings_factory import json
-from starlette.requests import Request
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response, StreamingResponse, JSONResponse
-from starlette.types import ASGIApp
 from starlette.concurrency import iterate_in_threadpool
-import re
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.types import ASGIApp
 
 
 class RalidatorStarlette(BaseHTTPMiddleware):
     def __init__(
-        self, app: ASGIApp, config: dict, filters_map: dict, ignore_paths: list
+        self,
+        app: ASGIApp,
+        config: dict,
+        filters_map: dict,
+        ignore_paths: list,
+        ignore_prefixes: list,
     ) -> None:
         super().__init__(app)
         self.ralidator_settings = RalidatorCoreSettingsFactory.from_dict(
@@ -21,6 +27,7 @@ class RalidatorStarlette(BaseHTTPMiddleware):
         )
         self.filters_map = filters_map
         self.ignore_paths = ignore_paths
+        self.ignore_prefixes = ignore_prefixes
 
     async def response_to_json(self, response: StreamingResponse | Response):
         if isinstance(response, StreamingResponse):
@@ -58,13 +65,18 @@ class RalidatorStarlette(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:
         if request.url.path in self.ignore_paths:
             return await call_next(request)
+
+        for prefix in self.ignore_prefixes:
+            if request.url.path.startswith(prefix):
+                return await call_next(request)
+
         ralidator = Ralidator(self.ralidator_settings, self.filters_map)
         request.state.ralidator = ralidator
         self.apply_ralidator_auth(request, ralidator)
         response = await call_next(request)
-        
-        if response.status_code >= 400: #Error codes
+
+        if response.status_code >= 400:  # Error codes
             return response
-        
+
         response = await self.apply_ralidator_filters(response, ralidator)
         return response

--- a/lightcurve/.env.example
+++ b/lightcurve/.env.example
@@ -7,6 +7,7 @@ MONGO_PASSWORD="mongo"
 MONGO_HOST="localhost"
 MONGO_PORT="27017"
 MONGO_DATABASE="database"
+MONGO_AUTH_SOURCE="admin"
 
 PSQL_USER="postgres"
 PSQL_PASSWORD="postgres"

--- a/lightcurve/scripts/run_dev.py
+++ b/lightcurve/scripts/run_dev.py
@@ -5,4 +5,4 @@ import uvicorn
 
 def run():
     port = os.getenv("PORT", default=8000)
-    uvicorn.run("api.api:app", port=port, reload=True)
+    uvicorn.run("api.api:app", port=int(port), reload=True)

--- a/lightcurve/src/api/api.py
+++ b/lightcurve/src/api/api.py
@@ -22,6 +22,8 @@ if os.getenv("ENV") != "dev":
             "/docs",
             "/metrics",
             "/openapi.json",
+        ],
+        ignore_prefixes=[
             "/static",
             "/htmx",
         ],

--- a/lightcurve/src/database/mongo.py
+++ b/lightcurve/src/database/mongo.py
@@ -1,4 +1,5 @@
 import os
+
 from pymongo import MongoClient
 
 user = os.getenv("MONGO_USER")
@@ -6,6 +7,8 @@ pwd = os.getenv("MONGO_PASSWORD")
 host = os.getenv("MONGO_HOST")
 port = os.getenv("MONGO_PORT")
 db = os.getenv("MONGO_DATABASE")
+auth_source = os.getenv("MONGO_AUTH_SOURCE")
+
 config = {
     "host": host,
     "serverSelectionTimeoutMS": 3000,  # 3 second timeout
@@ -13,8 +16,9 @@ config = {
     "password": pwd,
     "port": int(port),
     "database": db,
-    "authSource": db,
+    "authSource": auth_source,
 }
+
 database_name = config.pop("database")
 client = MongoClient(**config)
 database = client[database_name]

--- a/lightcurve/tests/conftest.py
+++ b/lightcurve/tests/conftest.py
@@ -455,6 +455,7 @@ def test_client():
     os.environ["MONGO_USER"] = "mongo"
     os.environ["MONGO_PASSWORD"] = "mongo"
     os.environ["MONGO_DATABASE"] = "database"
+    os.environ["MONGO_AUTH_SOURCE"] = "admin"
     os.environ["SECRET_KEY"] = "some_secret"
     from api.api import app
 

--- a/lightcurve/tests/conftest.py
+++ b/lightcurve/tests/conftest.py
@@ -132,6 +132,7 @@ def mongo_database():
     os.environ["MONGO_USER"] = "mongo"
     os.environ["MONGO_PASSWORD"] = "mongo"
     os.environ["MONGO_DATABASE"] = "database"
+    os.environ["MONGO_AUTH_SOURCE"] = "admin"
     os.environ["SECRET_KEY"] = "some_secret"
     from database.mongo import database
 


### PR DESCRIPTION
## Summary of the changes

Fix Internal Server Error caused by Ralidator middleware when accesing `lightcurve/static`. To fix this a new parameter was added to the ralidator middleware to ignore prefixes.

Fix authentication error when establishing a connection to the db through PyMongo caused by a miss configuration of the authSource field.