### PR TITLE
Fix: Lightcurve busqueda de objeto en mongo + psql no retorna objetos correctamente

### DIFF
--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -81,12 +81,6 @@ def get_lightcurve(
         handle_error(failure)
     if len(detections.unwrap()) == 0 and len(non_detections.unwrap()) == 0:
         handle_error(ObjectNotFound(oid))
-    print(
-        detections.unwrap(),
-        len(detections.unwrap()),
-        non_detections.unwrap(),
-        len(non_detections.unwrap()),
-    )
     return handle_success(
         {
             "detections": detections.unwrap(),

--- a/lightcurve/src/core/service.py
+++ b/lightcurve/src/core/service.py
@@ -77,15 +77,22 @@ def get_lightcurve(
     else:
         handle_error(SurveyIdError(survey_id))
     failure = fail_from_list([detections, non_detections])
-    if not failure:
-        return handle_success(
-            {
-                "detections": detections.unwrap(),
-                "non_detections": non_detections.unwrap(),
-            }
-        )
-    else:
+    if failure:
         handle_error(failure)
+    if len(detections.unwrap()) == 0 and len(non_detections.unwrap()) == 0:
+        handle_error(ObjectNotFound(oid))
+    print(
+        detections.unwrap(),
+        len(detections.unwrap()),
+        non_detections.unwrap(),
+        len(non_detections.unwrap()),
+    )
+    return handle_success(
+        {
+            "detections": detections.unwrap(),
+            "non_detections": non_detections.unwrap(),
+        }
+    )
 
 
 def get_detections(
@@ -138,11 +145,20 @@ def _get_all_unique_detections(
         sql_detections = _get_detections_sql(
             session_factory, oid, tid=survey_id
         )
+    except ObjectNotFound:
+        sql_detections = []
+    except DatabaseError as e:
+        return Failure(e)
+
+    try:
         mongo_detections = _get_detections_mongo(mongo_db, oid, tid=survey_id)
-    except (DatabaseError, ObjectNotFound) as e:
+    except ObjectNotFound:
+        mongo_detections = []
+    except DatabaseError as e:
         return Failure(e)
 
     detections = list(set(sql_detections + mongo_detections))
+
     return Success(detections)
 
 
@@ -239,14 +255,23 @@ def _get_all_unique_non_detections(
         sql_non_detections = _get_non_detections_sql(
             session_factory, oid, tid=survey_id
         )
+    except ObjectNotFound:
+        sql_non_detections = []
+    except DatabaseError as e:
+        return Failure(e)
+
+    try:
         mongo_non_detections = _get_non_detections_mongo(
             mongo_db, oid, tid=survey_id
         )
-
-        non_detections = list(set(sql_non_detections + mongo_non_detections))
-        return Success(non_detections)
-    except (DatabaseError, ObjectNotFound) as e:
+    except ObjectNotFound:
+        mongo_non_detections = []
+    except DatabaseError as e:
         return Failure(e)
+
+    non_detections = list(set(sql_non_detections + mongo_non_detections))
+
+    return Success(non_detections)
 
 
 def _get_detections_sql(
@@ -278,7 +303,9 @@ def _get_detections_mongo(
         obj = database["object"].find_one({"oid": oid}, {"_id": 1})
         if obj is None:
             raise ValueError()
-        result = database["detection"].find({"aid": obj["_id"], "tid": tid})
+        result = database["detection"].find(
+            {"aid": obj["_id"], "oid": oid, "tid": tid}
+        )
         result = [DetectionModel(**res, candid=res["_id"]) for res in result]
         return result
     except ValueError as e:
@@ -312,14 +339,12 @@ def _get_non_detections_sql(
 def _get_non_detections_mongo(
     database: Database, oid: str, tid: str
 ) -> list[NonDetectionModel]:
-    if tid == "atlas":
-        return []
     try:
         obj = database["object"].find_one({"oid": oid}, {"_id": 1})
         if obj is None:
             raise ValueError()
         result = database["non_detection"].find(
-            {"aid": obj["_id"], "tid": tid}
+            {"aid": obj["_id"], "oid": oid, "tid": tid}
         )
         result = [NonDetectionModel(**res) for res in result]
         return result

--- a/lightcurve/tests/conftest.py
+++ b/lightcurve/tests/conftest.py
@@ -150,7 +150,7 @@ def populate_psql(database):
 
 
 def add_psql_objects(session):
-    objects = [Object(oid="oid1"), Object(oid="oid2")]
+    objects = [Object(oid="oid1"), Object(oid="oid2"), Object(oid="oid20")]
     session.add_all(objects)
     session.commit()
 
@@ -189,6 +189,22 @@ def add_psql_detections(session):
             "has_stamp": False,
             "step_id_corr": "test",
         },
+        {
+            "candid": 789,
+            "oid": "oid20",
+            "mjd": 59001,
+            "fid": 2,
+            "pid": 1,
+            "isdiffpos": 1,
+            "ra": 11,
+            "dec": 21,
+            "magpsf": 14,
+            "sigmapsf": 0.4,
+            "corrected": False,
+            "dubious": False,
+            "has_stamp": False,
+            "step_id_corr": "test",
+        },
     ]
     detections = [Detection(**det) for det in detections]
     session.add_all(detections)
@@ -199,6 +215,7 @@ def add_psql_non_detections(session):
     non_detections = [
         {"oid": "oid1", "mjd": 59000, "fid": 1, "diffmaglim": 0.5},
         {"oid": "oid1", "mjd": 59001, "fid": 2, "diffmaglim": 0.4},
+        {"oid": "oid20", "mjd": 59002, "fid": 2, "diffmaglim": 0.4},
     ]
     non_detections = [NonDetection(**non) for non in non_detections]
     session.add_all(non_detections)
@@ -282,7 +299,7 @@ def add_mongo_objects(database: Database):
     }
     object2 = {
         "_id": "aid3",
-        "oid": ["oid1"],
+        "oid": ["oid1", "oid10"],
     }
     database["object"].insert_one(object1)
     database["object"].insert_one(object2)
@@ -410,6 +427,22 @@ def add_mongo_detections(database: Database):
             "dubious": False,
             "has_stamp": False,
         },  # Duplicated ZTF detection
+        {
+            "_id": "candid9",
+            "tid": "ztf",
+            "aid": "aid3",
+            "oid": "oid10",
+            "mjd": 59000,
+            "fid": 1,
+            "ra": 10,
+            "dec": 20,
+            "mag": 15,
+            "e_mag": 0.5,
+            "isdiffpos": 1,
+            "corrected": False,
+            "dubious": False,
+            "has_stamp": False,
+        },
     ]
     for det in detections:
         database.detection.insert_one(det)
@@ -433,6 +466,14 @@ def add_mongo_non_detections(database: Database):
             "fid": 1,
             "diffmaglim": 0.6,
         },  # unique ztf non detection
+        {
+            "tid": "ztf",
+            "aid": "aid3",
+            "oid": "oid10",
+            "mjd": 58000,
+            "fid": 1,
+            "diffmaglim": 0.6,
+        },
     ]
     for non_det in non_detections:
         database.non_detection.insert_one(non_det)

--- a/lightcurve/tests/test_api.py
+++ b/lightcurve/tests/test_api.py
@@ -4,8 +4,11 @@ def test_root(test_client):
 
 
 def test_detections_without_survey_id_param(
-    psql_service, init_psql, test_client,
-    mongo_service, init_mongo,
+    psql_service,
+    init_psql,
+    test_client,
+    mongo_service,
+    init_mongo,
 ):
     res = test_client.get("/detections/oid1")
     assert res.status_code == 200
@@ -13,18 +16,24 @@ def test_detections_without_survey_id_param(
 
 
 def test_detections_from_ztf(
-        psql_service, init_psql, test_client,
-        mongo_service, init_mongo,
-    ):
+    psql_service,
+    init_psql,
+    test_client,
+    mongo_service,
+    init_mongo,
+):
     res = test_client.get("/detections/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     assert len(res.json()) == 3
 
 
 def test_non_detections_from_ztf(
-        psql_service, init_psql, test_client,
-        mongo_service, init_mongo,
-    ):
+    psql_service,
+    init_psql,
+    test_client,
+    mongo_service,
+    init_mongo,
+):
     res = test_client.get("/non_detections/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     assert len(res.json()) == 3
@@ -42,7 +51,7 @@ def test_detections_with_unknown_survey_id_param(test_client):
 
 
 def test_lightcurve_from_atlas(mongo_service, init_mongo, test_client):
-    res = test_client.get("/lightcurve/oid1", params={"survey_id": "atlas"})
+    res = test_client.get("/lightcurve/oid2", params={"survey_id": "atlas"})
     assert res.status_code == 200
     json_res = res.json()
     # TODO: When a lightcurve contains only atlas detections and the user is
@@ -59,9 +68,12 @@ def test_lightcurve_from_atlas_without_results(
 
 
 def test_lightcurve_from_ztf(
-        psql_service, init_psql, test_client,
-        mongo_service, init_mongo,
-    ):
+    psql_service,
+    init_psql,
+    test_client,
+    mongo_service,
+    init_mongo,
+):
     res = test_client.get("/lightcurve/oid1", params={"survey_id": "ztf"})
     assert res.status_code == 200
     json_res = res.json()
@@ -74,3 +86,31 @@ def test_has_metrics(test_client):
     assert res.status_code == 200
     res = test_client.get("/metrics")
     assert res.status_code == 200
+
+
+def test_lightcurve_multistream_only_in_mongo(
+    psql_service,
+    init_psql,
+    test_client,
+    mongo_service,
+    init_mongo,
+):
+    res = test_client.get("/lightcurve/oid10")
+    assert res.status_code == 200
+    json_res = res.json()
+    assert len(json_res["detections"]) == 1
+    assert len(json_res["non_detections"]) == 1
+
+
+def test_lightcurve_multistream_only_in_psql(
+    psql_service,
+    init_psql,
+    test_client,
+    mongo_service,
+    init_mongo,
+):
+    res = test_client.get("/lightcurve/oid20")
+    assert res.status_code == 200
+    json_res = res.json()
+    assert len(json_res["detections"]) == 1
+    assert len(json_res["non_detections"]) == 1

--- a/lightcurve/tests/test_service.py
+++ b/lightcurve/tests/test_service.py
@@ -1,5 +1,4 @@
 import pytest
-
 from core.exceptions import AtlasNonDetectionError, SurveyIdError
 from core.models import Detection as DetectionModel
 from core.models import NonDetection as NonDetectionModel


### PR DESCRIPTION
## Summary of the changes

Update the behavior of lightcurve services to only return Not Found when the object cannot be found in both sql and mongo.

## Observations

Closes #246 

## About this PR:

- [x] You added the necessary documentation for the team to understand your work.
- [x] You linked this PR to the corresponding issue or user story.
- [x] Your changes fulfill the Definition of Done of the issue or user story.
- [x] Your changes were tested with manual testing before being submitted.
- [x] Your changes were tested with automatic unit tests.
- [x] Your changes were tested with automatic integration tests.