### PR TITLE
Refactor: Split htmx get lightcurve function

### DIFF
--- a/lightcurve/src/api/routes/htmx.py
+++ b/lightcurve/src/api/routes/htmx.py
@@ -170,6 +170,30 @@ async def lightcurve_app(
     show_dr: bool = False,
 ):
     lightcurve = await get_data_and_filter(request, oid, survey_id)
+    return templates.TemplateResponse(
+        name="lightcurve_app.html.jinja",
+        context={
+            "request": request,
+            "oid": oid,
+            "lightcurve": lightcurve,
+            "plot_type": plot_type,
+            "dr_detections": [],
+            "period": 0,
+            "dr_ids": dr_ids,
+            "dr": [],
+            "show_dr": show_dr
+        },
+    )
+
+@router.get("/lightcurve_dr", response_class=HTMLResponse)
+async def lightcurve_app(
+    request: Request,
+    oid: str,
+    survey_id: str = "all",
+    plot_type: str = "difference",
+    dr_ids: Annotated[list[str], Query()] = [],
+    show_dr: bool = False,
+):
     dr, dr_detections = await get_data_release_as_dict(oid, request.app.state.psql_session, dr_ids)
     period = get_period_value(oid, request.app.state.psql_session)
     return templates.TemplateResponse(
@@ -177,7 +201,7 @@ async def lightcurve_app(
         context={
             "request": request,
             "oid": oid,
-            "lightcurve": lightcurve,
+            #"lightcurve": lightcurve,
             "plot_type": plot_type,
             "dr_detections": dr_detections,
             "period": period,

--- a/lightcurve/src/api/routes/htmx.py
+++ b/lightcurve/src/api/routes/htmx.py
@@ -185,8 +185,8 @@ async def lightcurve_app(
         },
     )
 
-@router.get("/lightcurve_dr", response_class=HTMLResponse)
-async def lightcurve_app(
+@router.get("/lightcurve_detections", response_class=HTMLResponse)
+async def lightcurve_app_detect(
     request: Request,
     oid: str,
     survey_id: str = "all",

--- a/lightcurve/src/api/routes/htmx.py
+++ b/lightcurve/src/api/routes/htmx.py
@@ -185,8 +185,8 @@ async def lightcurve_app(
         },
     )
 
-@router.get("/lightcurve_detections", response_class=HTMLResponse)
-async def lightcurve_app_detect(
+@router.get("/lightcurve_complete", response_class=HTMLResponse)
+async def lightcurve_app_complete(
     request: Request,
     oid: str,
     survey_id: str = "all",
@@ -194,6 +194,7 @@ async def lightcurve_app_detect(
     dr_ids: Annotated[list[str], Query()] = [],
     show_dr: bool = False,
 ):
+    lightcurve = await get_data_and_filter(request, oid, survey_id)
     dr, dr_detections = await get_data_release_as_dict(oid, request.app.state.psql_session, dr_ids)
     period = get_period_value(oid, request.app.state.psql_session)
     return templates.TemplateResponse(
@@ -201,7 +202,7 @@ async def lightcurve_app_detect(
         context={
             "request": request,
             "oid": oid,
-            #"lightcurve": lightcurve,
+            "lightcurve": lightcurve,
             "plot_type": plot_type,
             "dr_detections": dr_detections,
             "period": period,


### PR DESCRIPTION
## Summary of the changes


Get lightcurve funcion get the lightcurve, the data release and the period in the same request. This makes the loadtime too long.

To resolve fast this we split the get lightcurve into 2:
1 only gets the lightcurve
2 get the whole data as before

## Observations

<-- Add some notes to keep in mind !-->


## If the change is BREAKING, please give more details about the breaking changes

<-- What change breaks what and how !-->

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->