### PR TITLE
changed initial values for crossmatch inputs to 20

### DIFF
--- a/lightcurve/src/crossmatch_api/static/crossmatch.js
+++ b/lightcurve/src/crossmatch_api/static/crossmatch.js
@@ -28,6 +28,8 @@ export function initCrossmatch() {
     let customInput = document.getElementById('customInput');
     let slider = document.getElementById('slider');
 
+    customInput.innerHTML = customInput.getAttribute('value');
+
     // Event listener of the slider
     slider.addEventListener('input', function() {
         customInput.innerHTML = this.value;

--- a/lightcurve/src/crossmatch_api/templates/crossmatch.html.jinja
+++ b/lightcurve/src/crossmatch_api/templates/crossmatch.html.jinja
@@ -15,7 +15,7 @@
             <p class="tw-text-black dark:tw-text-white"> Max. distance </p>
         </div>
         <div class="tw-grow tw-mx-4">
-            <input class="tw-w-full tw-h-[3px] tw-bg-blue-600 tw-rounded-lg tw-cursor-pointer dark:tw-bg-gray-700" type="range" id="slider" min="0" max="20" value="0" step="0.01">
+            <input class="tw-w-full tw-h-[3px] tw-bg-blue-600 tw-rounded-lg tw-cursor-pointer dark:tw-bg-gray-700" type="range" id="slider" min="0" max="20" value="20" step="0.01">
         </div>
         <div class="tw-flex">
             <div class="">
@@ -24,8 +24,8 @@
                     </svg>
             </div>
             <div class="tw-border-b tw-flex">
-                <div type="number" id="customInput" value="0" contenteditable="true" class="tw-text-black dark:tw-text-white tw-inline-block tw-p-[5px] tw-h-[30px] tw-w-[80px] tw-overflow-hidden tw-whitespace-nowrap tw-outline-none focus:tw-outline-none">
-                    0
+                <div type="number" id="customInput" value="20" contenteditable="true" class="tw-text-black dark:tw-text-white tw-inline-block tw-p-[5px] tw-h-[30px] tw-w-[80px] tw-overflow-hidden tw-whitespace-nowrap tw-outline-none focus:tw-outline-none">
+                    20
                 </div>
                 <div class="tw-mt-[6px]">
                     <p class="tw-text-black dark:tw-text-white">

--- a/lightcurve/src/crossmatch_api/templates/crossmatch.html.jinja
+++ b/lightcurve/src/crossmatch_api/templates/crossmatch.html.jinja
@@ -25,7 +25,6 @@
             </div>
             <div class="tw-border-b tw-flex">
                 <div type="number" id="customInput" value="20" contenteditable="true" class="tw-text-black dark:tw-text-white tw-inline-block tw-p-[5px] tw-h-[30px] tw-w-[80px] tw-overflow-hidden tw-whitespace-nowrap tw-outline-none focus:tw-outline-none">
-                    20
                 </div>
                 <div class="tw-mt-[6px]">
                     <p class="tw-text-black dark:tw-text-white">


### PR DESCRIPTION
The problem was that when the page initiated, crossmatch inputs shows 0 arcsec dist but shows objects with higher distances so that was bad. Now we changed that to show every object with at most 20 arcsec and show in both inputs 20 arcsec as the initial values.