### PR TITLE
added credits to catsHTM in the bottom of crossmatch card

### DIFF
--- a/lightcurve/src/crossmatch_api/routes/htmx.py
+++ b/lightcurve/src/crossmatch_api/routes/htmx.py
@@ -24,7 +24,7 @@ async def object_mag_app(
     request: Request,
     oid: str,
 ):
-    
+
     object = get_object(oid,session_factory = request.app.state.psql_session)
 
     cross = get_alerce_data(object.meanra, object.meandec, 20)
@@ -47,6 +47,6 @@ async def object_mag_app(
       name='crossmatch.html.jinja',
       context={'request': request,
                'cross': cross,
-               'crossKeys': cross_keys
+               'crossKeys': cross_keys,
                },
   )

--- a/lightcurve/src/crossmatch_api/templates/crossmatch.html.jinja
+++ b/lightcurve/src/crossmatch_api/templates/crossmatch.html.jinja
@@ -79,7 +79,18 @@
         </table>
     </div>
 
+    <div class="tw-flex tw-justify-between tw-w-[95%] tw-mx-auto tw-font-roboto">
+
+        <p id="dummy-p"> </p>
+        
+        <p class="tw-text-[#1e1e1e] dark:tw-text-white tw-text-xs tw-pt-3 tw-bottom-0 tw-right-0">
+            Powered by 
+            <a id="catsHTM-link" href="https://arxiv.org/abs/1805.02666" target="_blank" class="tw-inline tw-text-blue-600 tw-underline tw-cursor-pointer"> catsHTM </a>
+        </p>
+    </div>
+
 </div>
+     
 
 <script type="module">
     import { initCrossmatch, elementReady } from "{{API_URL}}/static/crossmatch.js";


### PR DESCRIPTION
The xmatch card hadn't the credits to the [catsHTM paper](https://arxiv.org/abs/1805.02666) so we added a div with a paragraph to add the text with a link. 