### PR TITLE
tns icon is now hosted in s3

### DIFF
--- a/lightcurve/src/object_api/templates/tnsInformation.html.jinja
+++ b/lightcurve/src/object_api/templates/tnsInformation.html.jinja
@@ -34,7 +34,7 @@
         </div>
         <p class="tw-text-[#1e1e1e] dark:tw-text-white tw-h-auto tw-text-xs">
         Provided by
-            <a id="tns-link" href="{{tns_link}}" target="_blank" class=" tw-inline tw-text-blue-600 tw-underline tw-cursor-pointer">TNS</a>  <img class="tw-inline" src="https://www.wis-tns.org/sites/default/files/favicon.png">
+            <a id="tns-link" href="{{tns_link}}" target="_blank" class=" tw-inline tw-text-blue-600 tw-underline tw-cursor-pointer">TNS</a>  <img class="tw-inline" src="https://alerce-static.s3.amazonaws.com/logos/tns_icon_small.png">
         </p>
     </div>
 </div>


### PR DESCRIPTION
## Summary of the changes

The TNS icon is now hosted in S3 (alerce-static) instead of making an https query to tns in the browser. This avoids an extra connection and hitting TNS.


## Observations

<-- Add some notes to keep in mind !-->


## If the change is BREAKING, please give more details about the breaking changes

<-- What change breaks what and how !-->

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->