### PR TITLE
refactor: organize lightcurve API routes by response format

### DIFF
--- a/multisurveys-apis/src/lightcurve_api/api.py
+++ b/multisurveys-apis/src/lightcurve_api/api.py
@@ -3,7 +3,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
-from .routes import rest, conesearch
+from .routes.htmx import lightcurve as htmx_lightcurve
+from .routes.json import conesearch, lightcurve as json_lightcurve
 
 app = FastAPI(openapi_url="/v2/lightcurve/openapi.json")
 instrumentator = Instrumentator().instrument(app).expose(app)
@@ -19,7 +20,7 @@ app.add_middleware(
 
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 
-app.include_router(rest.router)
+app.include_router(json_lightcurve.router)
 app.include_router(conesearch.router)
 
 app.mount(

--- a/multisurveys-apis/src/lightcurve_api/routes/json/conesearch.py
+++ b/multisurveys-apis/src/lightcurve_api/routes/json/conesearch.py
@@ -6,9 +6,9 @@ from fastapi import APIRouter, HTTPException
 from core.config.dependencies import db_dependency
 from core.idmapper import idmapper
 
-from ..models.lightcurve import Lightcurve
-from ..models.object import ApiObject
-from ..services.conesearch import conesearch as service
+from ...models.lightcurve import Lightcurve
+from ...models.object import ApiObject
+from ...services.conesearch import conesearch as service
 
 router = APIRouter(prefix="/conesearch")
 

--- a/multisurveys-apis/src/lightcurve_api/routes/json/lightcurve.py
+++ b/multisurveys-apis/src/lightcurve_api/routes/json/lightcurve.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from core.config.dependencies import db_dependency
 
-from ..services.lightcurve_service import (
+from ...services.lightcurve_service import (
     get_detections,
     get_detections_by_list,
     get_forced_photometry,
@@ -13,7 +13,7 @@ from ..services.lightcurve_service import (
     get_non_detections,
     get_non_detections_by_list,
 )
-from ..services.validations import survey_validate
+from ...services.validations import survey_validate
 
 router = APIRouter()
 


### PR DESCRIPTION
## Summary of the changes

Refactor API directory structure separated by response type.

## If the change is BREAKING, please give more details about the breaking changes

Import path has changed, but nothing external should be importing the API routes, I think.