### PR TITLE
feat: non_detections queries return empty list for LSST instead of ra…

### DIFF
--- a/multisurveys-apis/src/core/repository/queries/non_detections.py
+++ b/multisurveys-apis/src/core/repository/queries/non_detections.py
@@ -34,7 +34,7 @@ def get_non_detections_by_list(session_factory):
         oids, survey_id = args
 
         if survey_id.lower() != "ztf":
-            raise ValueError("Survey not supported")
+            return [], survey_id
 
         session: Session
         with session_factory() as session:

--- a/multisurveys-apis/src/lightcurve_api/services/parsers.py
+++ b/multisurveys-apis/src/lightcurve_api/services/parsers.py
@@ -4,7 +4,7 @@ from sqlalchemy import Row
 
 from ..models.detections import LsstDetection, ztfDetection
 from ..models.force_photometry import LsstForcedPhotometry, ZtfForcedPhotometry
-from ..models.non_detections import LsstNonDetection, ZtfNonDetections
+from ..models.non_detections import ZtfNonDetections
 
 
 def parse_sql_detection(args: Tuple[Sequence[Row[Any]], str]):
@@ -27,12 +27,10 @@ def parse_sql_detection(args: Tuple[Sequence[Row[Any]], str]):
 def parse_sql_non_detections(args: Tuple[Sequence[Row[Any]], str]):
     sql_response, survey_id = args
 
-    if survey_id == "lsst":
-        non_detections = ModelsParser(LsstNonDetection, sql_response, survey_id)
-    else:
-        non_detections = ModelsParser(ZtfNonDetections, sql_response, "")
+    if survey_id.lower() != "ztf":
+        return []
 
-    return non_detections.parse_data_arr()
+    return ModelsParser(ZtfNonDetections, sql_response, survey_id).parse_data_arr()
 
 
 def parse_forced_photometry(args: Tuple[Sequence[Row[Any]], str]):


### PR DESCRIPTION
## Summary of the changes

1. **Non-detections query handling**: Modified `get_non_detections_by_list` to return empty list instead of raising ValueError for unsupported surveys (currently only ZTF supported).

2. **Parser simplification**: 
   - Removed unused LSST non-detection model import
   - Simplified `parse_sql_non_detections` to handle only ZTF surveys, returning empty list for others
   - Removed LSST-specific non-detection parsing logic

**Key Changes:**
- Error handling changed from raising exceptions to returning empty results for unsupported surveys
- Code cleanup by removing unused LSST non-detection functionality
- Focus maintained on ZTF survey support only
