### PR TITLE
feat: add HTMX lightcurve endpoint and multi-survey support

### DIFF
--- a/multisurveys-apis/src/lightcurve_api/api.py
+++ b/multisurveys-apis/src/lightcurve_api/api.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
+from .routes.htmx import lightcurve as htmx_lightcurve
 from .routes.json import conesearch, lightcurve as json_lightcurve
 
 app = FastAPI(openapi_url="/v2/lightcurve/openapi.json")
@@ -21,6 +22,7 @@ app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 app.include_router(json_lightcurve.router)
 app.include_router(conesearch.router)
+app.include_router(htmx_lightcurve.router)
 
 app.mount(
     "/static",

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/lightcurve.py
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/lightcurve.py
@@ -1,0 +1,26 @@
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from lightcurve_api.services.lightcurve_plot_service import service as lightcurve_plot_service
+from core.config.dependencies import db_dependency
+
+router = APIRouter(prefix="/htmx")
+
+templates = Jinja2Templates(
+    directory="src/lightcurve_api/routes/htmx/templates",
+    autoescape=True,
+    auto_reload=True,
+)
+
+templates.env.globals["API_URL"] = os.getenv("API_URL", "http://localhost:8001")
+
+
+@router.get("/lightcurve", response_class=HTMLResponse)
+def lightcurve(request: Request, oid: str, survey_id: str, db: db_dependency):
+    result, config_state = lightcurve_plot_service.lightcurve_plot(oid, survey_id, db.session)
+    return templates.TemplateResponse(
+        name="lightcurve.html.jinja",
+        context={"request": request, "options": result.echart_options, "config_state": config_state},
+    )

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/lightcurve.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/lightcurve.html.jinja
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <!-- Include the ECharts file you just downloaded -->
+    <script src="{{API_URL}}/static/echarts.min.js"></script>
+    <script src="{{API_URL}}/static/htmx.min.js"></script>
+    <meta name="htmx-config" content='{"selfRequestsOnly": false}'>
+    <link rel="stylesheet" href="{{ API_URL }}/static/main.css">
+  </head>
+  <body>
+    <!-- Prepare a DOM with a defined width and height for ECharts -->
+    <div id="lightcurve-multisurvey" style="width: 100%;height:100%;min-height:400px;"></div>
+    <script type="text/javascript">
+      // Initialize the echarts instance based on the prepared dom
+      var chartDom = document.getElementById('lightcurve-multisurvey')
+      var myChart = echarts.init(chartDom);
+      const options = {{ options | tojson }};
+
+      // Make chart responsive
+      window.addEventListener('resize', function() {
+        const threshold = 1100;
+        const containerWidth = chartDom.offsetWidth;
+        const newOption = {
+          legend: {orient: 'horizontal', bottom: 0},
+          grid: {bottom: "30%"}
+        };
+        const oldOption = {
+          legend: options.legend,
+          grid: options.grid
+        }
+        if (containerWidth < threshold) {
+          myChart.setOption(newOption);
+        } else {
+          myChart.setOption(oldOption);
+        }
+
+        myChart.resize();
+      });
+
+      // Display the chart using the configuration items and data just specified.
+      myChart.setOption(options);
+    </script>
+
+  </body>
+</html>

--- a/multisurveys-apis/src/lightcurve_api/services/conesearch/parser.py
+++ b/multisurveys-apis/src/lightcurve_api/services/conesearch/parser.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, cast
 from db_plugins.db.sql.models import Object
 
 from lightcurve_api.models.object import ApiObject
@@ -6,10 +6,17 @@ from core.idmapper.idmapper import decode_masterid
 from numpy import int64
 
 
+def survey_id_map(sid: int) -> str:
+    return "ztf" if sid == 1 else "lsst"
+
+
 def parse_api_object(sql_object: Object) -> ApiObject:
-    _, parsedOid = decode_masterid(int64(str(sql_object.oid)))
+    objectId = sql_object.oid
+    if survey_id_map(cast(int, sql_object.sid)) == "ztf":
+        _, objectId = decode_masterid(int64(str(sql_object.oid)))
     return ApiObject(
-        objectId=str(parsedOid),
+        objectId=str(objectId),
+        survey_id=survey_id_map(cast(int, sql_object.sid)),
         ra=sql_object.meanra,  # type: ignore
         dec=sql_object.meandec,  # type: ignore
     )

--- a/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/chart_point.py
+++ b/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/chart_point.py
@@ -1,0 +1,17 @@
+from typing import List
+
+
+class ChartPoint:
+    survey: str
+    band: str
+    x: float
+    y: float
+
+    def __init__(self, survey: str, band: str, x: float, y: float):
+        self.survey = survey
+        self.band = band
+        self.x = x
+        self.y = y
+
+    def point(self) -> List[float]:
+        return [self.x, self.y]

--- a/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/result.py
+++ b/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/result.py
@@ -1,0 +1,23 @@
+import copy
+from typing import Any
+
+from ...models.lightcurve import Lightcurve
+
+
+class Result:
+    echart_options: dict[str, Any]
+    lightcurve: Lightcurve
+
+    def __init__(self, echart_options: dict[str, Any], lightcurve: Lightcurve):
+        self.echart_options = echart_options
+        self.lightcurve = lightcurve
+
+    def copy(self):
+        return Result(
+            echart_options=copy.deepcopy(self.echart_options),
+            lightcurve=Lightcurve(
+                detections=copy.deepcopy(self.lightcurve.detections),
+                non_detections=copy.deepcopy(self.lightcurve.non_detections),
+                forced_photometry=copy.deepcopy(self.lightcurve.forced_photometry),
+            ),
+        )

--- a/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/service.py
+++ b/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/service.py
@@ -1,0 +1,222 @@
+import copy
+from collections import defaultdict
+from typing import Any, Callable, ContextManager, List, Tuple, cast
+
+from sqlalchemy.orm.session import Session
+from toolz import pipe
+
+from lightcurve_api.models.lightcurve import Lightcurve
+from lightcurve_api.models.lightcurve_item import (
+    BaseDetection,
+    BaseForcedPhotometry,
+    BaseNonDetection,
+)
+
+from ..conesearch.conesearch import conesearch_oid_lightcurve
+from .chart_point import ChartPoint
+from .result import Result
+
+DEFAULT_RADIUS = 30
+DEFAULT_NEIGHBORS = 2
+DETECTION = "det"
+NON_DETECTION = "lim. mag"
+FORCED_PHOTOMETRY = "f. phot"
+COLORS = {
+    "ztf": {"g": "#56E03A", "r": "#D42F4B", "i": "#F4D617"},
+    "lsst": {"u": "#1600EA", "g": "#31DE1F", "r": "#B52626", "i": "#370201", "z": "#BA52FF", "y": "#61A2B3"},
+}
+SYMBOLS = {
+    "ztf": {DETECTION: "circle", NON_DETECTION: "triangle", FORCED_PHOTOMETRY: "rect"},
+    "lsst": {DETECTION: "roundRect", NON_DETECTION: "diamond", FORCED_PHOTOMETRY: "arrow"},
+}
+
+
+def default_config_state():
+    return {
+        "ztf_bands": ["g", "r", "i"],
+        "lsst_bands": ["u", "g", "r", "i", "z", "y"],
+        "flux": False,
+        "magnitude": True,
+        "apparent": True,
+        "absolute": False,
+        "difference": True,
+        "total": False,
+        "external_sources": [],
+        "external_sources_enabled": False,
+        "offset_bands": False,
+    }
+
+
+def create_series(name: str, survey: str, band: str, data: List[List[float]]) -> dict:
+    return {
+        "name": name + " " + survey.upper() + ": " + band,
+        "type": "scatter",
+        "data": data,
+        "color": COLORS[survey][band],
+        "symbol": SYMBOLS[survey][name],
+    }
+
+
+def default_echarts_options():
+    return {
+        "tooltip": {},
+        "grid": {"right": "21%", "left": "5%", "bottom": "10%"},
+        "legend": {
+            "right": 0,
+            "top": 80,
+            "orient": "vertical",
+            "selectedMode": False,
+            "itemWidth": 15,
+        },
+        "xAxis": {"type": "value", "name": "MJD", "scale": True},
+        "yAxis": {"type": "value", "name": "Magnitude", "scale": True},
+        "series": [],
+    }
+
+
+def lightcurve_plot(
+    oid: str, survey_id: str, session_factory: Callable[..., ContextManager[Session]]
+) -> Tuple[Result, dict[str, Any]]:
+    result = Result({}, Lightcurve(detections=[], non_detections=[], forced_photometry=[]))
+    return cast(
+        Tuple[Result, dict],
+        pipe(
+            get_lightcurve(oid, result, survey_id, session_factory),
+            create_echart_options,
+            set_chart_options_detections,
+            set_chart_options_non_detections,
+            set_chart_options_forced_photometry,
+        ),
+    )
+
+
+def get_lightcurve(oid: str, result: Result, survey_id: str, session_factory: Callable[..., ContextManager[Session]]):
+    return Result(
+        copy.deepcopy(result.echart_options),
+        conesearch_oid_lightcurve(
+            oid,
+            DEFAULT_RADIUS,
+            DEFAULT_NEIGHBORS,
+            survey_id,
+            session_factory,
+        ),
+    )
+
+
+def create_echart_options(result: Result) -> Tuple[Result, dict[str, Any]]:
+    result_copy = result.copy()
+    chart_options = default_echarts_options()
+    result_copy.echart_options = chart_options
+    config_state = default_config_state()
+    return result_copy, config_state
+
+
+def set_chart_options_detections(args: Tuple[Result, dict[str, Any]]) -> Tuple[Result, dict[str, Any]]:
+    result, config_state = args
+
+    result_copy = result.copy()
+    config_state_copy = copy.deepcopy(config_state)
+    detections_grouped: dict[str, dict[str, List[List[float]]]] = defaultdict(lambda: defaultdict(lambda: []))
+
+    # Group detections by survey and band
+    for chart_point in create_chart_detections(result_copy.lightcurve.detections, config_state_copy):
+        detections_grouped[chart_point.survey][chart_point.band].append(chart_point.point())
+
+    # Create echart series for each survey and band
+    for survey in detections_grouped:
+        for band, data in detections_grouped[survey].items():
+            result_copy.echart_options["series"].append(create_series(DETECTION, survey, band, data))
+
+    return result_copy, config_state_copy
+
+
+def set_chart_options_non_detections(args: Tuple[Result, dict[str, Any]]) -> Tuple[Result, dict[str, Any]]:
+    result, config_state = args
+
+    result_copy = result.copy()
+    config_state_copy = copy.deepcopy(config_state)
+    grouped: dict[str, dict[str, List[List[float]]]] = defaultdict(lambda: defaultdict(lambda: []))
+
+    # Group non detections by survey and band
+    for chart_point in create_chart_non_detections(result_copy.lightcurve.non_detections, config_state_copy):
+        grouped[chart_point.survey][chart_point.band].append(chart_point.point())
+
+    # Create echart series for each survey and band
+    for survey in grouped:
+        for band, data in grouped[survey].items():
+            result_copy.echart_options["series"].append(create_series(NON_DETECTION, survey, band, data))
+
+    return result_copy, config_state_copy
+
+
+def set_chart_options_forced_photometry(args: Tuple[Result, dict[str, Any]]) -> Tuple[Result, dict[str, Any]]:
+    result, config_state = args
+
+    result_copy = result.copy()
+    config_state_copy = copy.deepcopy(config_state)
+    grouped: dict[str, dict[str, List[List[float]]]] = defaultdict(lambda: defaultdict(lambda: []))
+
+    # Group forced photometry by survey and band
+    for chart_point in create_chart_forced_photometry(result_copy.lightcurve.forced_photometry, config_state_copy):
+        grouped[chart_point.survey][chart_point.band].append(chart_point.point())
+
+    # Create echart series for each survey and band
+    for survey in grouped:
+        for band, data in grouped[survey].items():
+            result_copy.echart_options["series"].append(create_series(FORCED_PHOTOMETRY, survey, band, data))
+
+    return result_copy, config_state_copy
+
+
+def create_chart_detections(detections: List[BaseDetection], config_state: dict[str, Any]) -> List[ChartPoint]:
+    result = []
+    for det in detections:
+        if det.band_name() not in config_state["ztf_bands"] + config_state["lsst_bands"]:
+            continue
+
+        result.append(
+            ChartPoint(
+                det.survey_id,
+                det.band_name(),
+                det.mjd,
+                det.magnitude2flux(config_state["difference"])
+                if config_state["flux"]
+                else det.flux2magnitude(config_state["difference"]),
+            )
+        )
+
+    return result
+
+
+def create_chart_non_detections(
+    non_detections: List[BaseNonDetection], config_state: dict[str, Any]
+) -> List[ChartPoint]:
+    result = []
+    for ndet in non_detections:
+        if ndet.band_name() not in config_state["ztf_bands"] + config_state["lsst_bands"]:
+            continue
+
+        result.append(ChartPoint(ndet.survey_id, ndet.band_name(), ndet.mjd, ndet.get_mag()))
+
+    return result
+
+
+def create_chart_forced_photometry(
+    forced_photometry: List[BaseForcedPhotometry], config_state: dict[str, Any]
+) -> List[ChartPoint]:
+    result = []
+    for fphot in forced_photometry:
+        if fphot.band_name() not in config_state["ztf_bands"] + config_state["lsst_bands"]:
+            continue
+
+        result.append(
+            ChartPoint(
+                fphot.survey_id,
+                fphot.band_name(),
+                fphot.mjd,
+                fphot.magnitude2flux(config_state["difference"])
+                if config_state["flux"]
+                else fphot.flux2magnitude(config_state["difference"]),
+            )
+        )
+    return result

--- a/multisurveys-apis/src/lightcurve_api/services/lightcurve_service.py
+++ b/multisurveys-apis/src/lightcurve_api/services/lightcurve_service.py
@@ -51,7 +51,7 @@ def get_detections_by_list(
 
 
 def convert_oid_list_to_int(
-    args: Tuple[List[str], str],
+    args: Tuple[List[int] | List[str], str],
 ) -> Tuple[List[int], str]:
     oid_list, survey_id = args
 

--- a/multisurveys-apis/src/lightcurve_api/services/parsers.py
+++ b/multisurveys-apis/src/lightcurve_api/services/parsers.py
@@ -47,6 +47,9 @@ def parse_forced_photometry(args: Tuple[Sequence[Row[Any]], str]):
 
 
 class ModelsParser:
+    class ParseError(Exception):
+        pass
+
     def __init__(self, output_model, sql_response, survey_id):
         self.output_model = output_model
         self.sql_response = sql_response
@@ -56,8 +59,11 @@ class ModelsParser:
         data_parsed = []
         for row in self.sql_response:
             model_dict = self.transform_models_to_dict(row)
-            model_parsed = self.output_model(**model_dict, survey_id=self.survey_id)
-            data_parsed.append(model_parsed)
+            try:
+                model_parsed = self.output_model(**model_dict, survey_id=self.survey_id)
+                data_parsed.append(model_parsed)
+            except Exception as e:
+                raise self.ParseError(f"Error parsing {self.output_model.__name__} model: {e}")
 
         return data_parsed
 

--- a/multisurveys-apis/tests/lightcurve_api/conftest.py
+++ b/multisurveys-apis/tests/lightcurve_api/conftest.py
@@ -231,6 +231,10 @@ def _generate_lsst_detection(faker: Faker, oid, idx) -> Tuple[Detection, LsstDet
         x=1,
         y=1,
         timeProcessedMjdTai=1,
+        psfFlux=faker.pyfloat(min_value=50, max_value=300),
+        psfFluxErr=faker.pyfloat(min_value=0, max_value=2),
+        scienceFlux=faker.pyfloat(min_value=50, max_value=300),
+        scienceFluxErr=faker.pyfloat(min_value=0, max_value=2),
     )
 
 
@@ -306,4 +310,8 @@ def _generate_lsst_forced_photometry(faker: Faker, oid, idx):
         visit=faker.random_int(),
         detector=faker.random_int(),
         timeProcessedMjdTai=faker.random_int(),
+        psfFlux=faker.pyfloat(min_value=50, max_value=300),
+        psfFluxErr=faker.pyfloat(min_value=0, max_value=2),
+        scienceFlux=faker.pyfloat(min_value=50, max_value=300),
+        scienceFluxErr=faker.pyfloat(min_value=0, max_value=2),
     )

--- a/multisurveys-apis/tests/lightcurve_api/routes/test_conesearch_routes.py
+++ b/multisurveys-apis/tests/lightcurve_api/routes/test_conesearch_routes.py
@@ -108,6 +108,7 @@ def test_oid_lightcurve(client: TestClient, populate_database):
             "neighbors": "10",
         },
     )
+    print(response.json())
     assert response.status_code == 200
     assert len(response.json()["detections"]) >= 1
     assert len(response.json()["non_detections"]) >= 1

--- a/multisurveys-apis/tests/lightcurve_api/services/conesearch/test_conesearch.py
+++ b/multisurveys-apis/tests/lightcurve_api/services/conesearch/test_conesearch.py
@@ -25,7 +25,7 @@ def test_conesearch_coordinates(mocker):
     # Setup the database mock
     # Result has to be a list of tuples
     # where the first element is the object
-    mock = database_mock(mocker, [(Object(oid=123, meanra=45.0, meandec=45.0),)])
+    mock = database_mock(mocker, [(Object(oid=123, meanra=45.0, meandec=45.0, sid=1),)])
     implement_context_manager(mocker, mock)
 
     # Call the service
@@ -33,7 +33,7 @@ def test_conesearch_coordinates(mocker):
     result = conesearch_service.conesearch_coordinates(ra, dec, radius, neighbors, mock)
 
     # Assert that the result is as expected
-    assert result == [ApiObject(objectId="ZTF00aaaaaet", ra=45.0, dec=45.0)]
+    assert result == [ApiObject(objectId="ZTF00aaaaaet", ra=45.0, dec=45.0, survey_id="ztf")]
     mock.execute.assert_called_once()
     call_args = mock.execute.call_args[0]
     assert call_args[1] == {"ra": 45.0, "dec": 45.0, "radius": 30.0}
@@ -53,14 +53,14 @@ def test_conesearch_oid(mocker):
     # Setup the database mock
     # Result has to be a list of tuples
     # where the first element is the object
-    mock = database_mock(mocker, [(Object(oid=123, meanra=45.0, meandec=45.0),)])
+    mock = database_mock(mocker, [(Object(oid=123, meanra=45.0, meandec=45.0, sid=1),)])
     implement_context_manager(mocker, mock)
 
     # Call the service
     result = conesearch_service.conesearch_oid(int64(123), 30.0, 10, mock)
 
     # Assert that the result is as expected
-    assert result == [ApiObject(objectId="ZTF00aaaaaet", ra=45.0, dec=45.0)]
+    assert result == [ApiObject(objectId="ZTF00aaaaaet", ra=45.0, dec=45.0, survey_id="ztf")]
     mock.execute.assert_called_once()
     call_args = mock.execute.call_args[0]
     assert call_args[1] == {"radius": 30.0}
@@ -100,7 +100,7 @@ def test_conesearch_oid_lightcurve(mocker):
 
         if "q3c_radial_query" in stmt and "target.meanra" in stmt:
             # conesearch query
-            return wrapper([(Object(oid=123, meanra=45.0, meandec=45.0),)])
+            return wrapper([(Object(oid=123, meanra=45.0, meandec=45.0, sid=1),)])
         elif "detection" in stmt.lower() and "non_detection" not in stmt.lower():
             # detections query
             return wrapper([(make_ztf_detection(123, 1, 1),)])

--- a/multisurveys-apis/tests/lightcurve_api/services/conesearch/test_parser.py
+++ b/multisurveys-apis/tests/lightcurve_api/services/conesearch/test_parser.py
@@ -4,6 +4,6 @@ from lightcurve_api.services.conesearch.parser import parse_api_object
 
 
 def test_parse_api_object():
-    assert ApiObject(objectId="ZTF00aaaaaet", ra=45.0, dec=45.0) == parse_api_object(
-        Object(oid=123, meanra=45.0, meandec=45.0)
+    assert ApiObject(objectId="ZTF00aaaaaet", ra=45.0, dec=45.0, survey_id="ztf") == parse_api_object(
+        Object(oid=123, meanra=45.0, meandec=45.0, sid=1)
     )


### PR DESCRIPTION
## Summary of the changes
#### 1. HTMX Lightcurve Endpoint (`/htmx/lightcurve`)
- New endpoint that returns HTML with embedded ECharts visualization
- Uses Jinja2 templates for server-side rendering
- Includes responsive chart behavior for different screen sizes

#### 2. Multi-Survey Support in Conesearch
- Modified `get_detections`, `get_non_detections`, and `get_forced_photometry` to handle multiple surveys
- Added survey_id mapping and parsing logic
- Updated data grouping to organize by survey and band

#### 3. Lightcurve Plotting Service
- New service that transforms lightcurve data into ECharts configuration
- Supports detections, non-detections, and forced photometry
- Configurable display options (flux/magnitude, bands, etc.)
- Proper error handling in model parsing

#### 4. Test Updates
- Added test data for LSST flux values
- Updated test assertions to include survey_id field
- Enhanced model parsing with proper error handling



## Screensshots

<img width="2876" height="932" alt="image" src="https://github.com/user-attachments/assets/d4290112-9ebe-4b68-821f-8ca964174f8a" />
