### PR TITLE
feat: add periodogram chart

### DIFF
--- a/multisurveys-apis/src/core/periodogram/periodogram.py
+++ b/multisurveys-apis/src/core/periodogram/periodogram.py
@@ -1,3 +1,4 @@
+from lightcurve_api.models.periodogram import Periodogram
 import numpy as np
 import pandas as pd
 from P4J import MultiBandPeriodogram
@@ -74,15 +75,19 @@ class PeriodogramComputer:
 
         self.periodogram_computer.optimal_finetune_best_frequencies(times_finer=10.0, n_local_optima=10)
 
-        best_freq, best_per = self.periodogram_computer.get_best_frequencies()
+        best_freq, _ = self.periodogram_computer.get_best_frequencies()
 
         freq, score = self.periodogram_computer.get_periodogram()
         period = 1 / freq
 
-        return {
-            "period": period.tolist(),
-            "score": score.tolist(),
-            "best_periods": (1.0 / best_freq).tolist(),
-            "best_periods_index": self.periodogram_computer.best_local_optima,
-            "best_period": best_per,
-        }
+        local_optima = (
+            [self.periodogram_computer.best_local_optima]
+            if isinstance(self.periodogram_computer.best_local_optima, int)
+            else self.periodogram_computer.best_local_optima
+        )
+        return Periodogram(
+            periods=period.tolist(),
+            scores=score.tolist(),
+            best_periods=(1.0 / best_freq).tolist(),
+            best_periods_index=local_optima,
+        )

--- a/multisurveys-apis/src/lightcurve_api/models/periodogram.py
+++ b/multisurveys-apis/src/lightcurve_api/models/periodogram.py
@@ -1,0 +1,28 @@
+from typing import List
+from pydantic import BaseModel
+
+
+class NoPeriodError(Exception):
+    def __init__(self):
+        super().__init__()
+
+
+class Periodogram(BaseModel):
+    periods: List[float]
+    scores: List[float]
+    best_periods: List[float]
+    best_periods_index: List[int]
+
+    def get_best_period(self):
+        if len(self.best_periods_index) == 0:
+            raise NoPeriodError()
+
+        return round(self.periods[self.best_periods_index[0]], 3)
+
+    def serialize(self):
+        return {
+            "periods": self.periods,
+            "scores": self.scores,
+            "best_periods": self.best_periods,
+            "best_periods_index": self.best_periods_index,
+        }

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/parsers.py
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/parsers.py
@@ -35,6 +35,7 @@ class ConfigState(BaseModel):
     offset_num: int = 1
     offset_metric: str = "median"
     period: float = 0.05
+    periodogram_enabled: bool = False
 
     # detections, non_detections and forced_photometry are sent as json strings
     # that need to be parsed

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja
@@ -4,8 +4,8 @@
 
 <form 
   hx-ext="form-json"
-  hx-post="/htmx/config_change" 
-  hx-target="#main-app" 
+  hx-post="{{API_URL}}/htmx/config_change"
+  hx-target="#main-app"
   hx-trigger="change delay:200ms"
 >
   <input type="hidden" name="oid" value="{{ config_state.oid }}">
@@ -44,7 +44,7 @@
     <button 
       class="ml-2 p-1.5 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
       aria-label="Filter external sources"
-      hx-post="/htmx/external_sources"
+      hx-post="{{API_URL}}/htmx/external_sources"
     >
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z"></path>
@@ -77,7 +77,7 @@
   <div class="w-full h-px bg-gray-200 my-3"></div>
 
   <a
-    href="/htmx/download?oid={{config_state.oid}}&survey_id={{config_state.survey_id}}"
+    href="{{API_URL}}/htmx/download?oid={{config_state.oid}}&survey_id={{config_state.survey_id}}"
     class="flex items-center justify-center gap-2 px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors duration-200 text-sm"
     download
   >
@@ -87,3 +87,4 @@
     Download
   </a>
 </form>
+

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/external_sources.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/external_sources.html.jinja
@@ -1,5 +1,5 @@
 <form id="dr-table"
-  hx-post="/htmx/config_change"
+  hx-post="{{API_URL}}/htmx/config_change"
   hx-target="#main-app"
   hx-vals='{{config_state.model_dump_json(exclude=["external_sources"])}}'
   hx-ext="form-json"

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/fold_controls.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/fold_controls.html.jinja
@@ -11,6 +11,10 @@
       <span name="div2" class="px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors cursor-pointer select-none">/2</span>
     </div>
   </div>
+  <div class="col-sm-12 mt-2">
+    <span class="font-semibold mr-3">Periodogram</span>
+    {{ toggle.toggle("periodogram_enabled", "Off", "On", config_state.periodogram_enabled)}}
+  </div>
 </div>
 
 <script>
@@ -41,4 +45,9 @@ div2.addEventListener('click', function(e) {
   if (input.value < 0.05) input.value = 0.05
   input.dispatchEvent(new Event('change', { bubbles: true }));
 })
+
+document.addEventListener('periodogram:periodSelected', function(event) {
+  input.value = event.detail.period;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+});
 </script>

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/lightcurve.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/lightcurve.html.jinja
@@ -1,4 +1,4 @@
-<div id="chart" style="width: 100%;height:100%;min-height:400px;"></div>
+<div id="chart" style="width: 100%;height:100%;"></div>
 <script type="text/javascript">
 // Initialize the echarts instance based on the prepared dom
 var chartDom = document.getElementById('chart')
@@ -6,7 +6,11 @@ var myChart = echarts.init(chartDom);
 var options = {{ options | tojson }};
 
 // Make chart responsive
-window.addEventListener('resize', myChart.resize);
+var plotGrid = document.getElementById('plot-grid');
+var resizeObserver = new ResizeObserver(_ => {
+  myChart.resize();
+});
+resizeObserver.observe(plotGrid);
 
 // Register a custom series type so that it can be references as string in the chart options.
 var renderError = (_, api) => {

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/main.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/main.html.jinja
@@ -1,13 +1,12 @@
-<div class="grid grid-cols-12">
-  <div class="col-span-2 text-center ml-3">{% include "config_panel.html.jinja" %}</div>
-  <div class="col-span-10">
-    {% if detections %}
-      {% set not_corrected = detections[0].flux2magnitude(True) == 0 %}
-    {% else %}
-      {% set not_corrected = True %}
-    {% endif %}
+{% if detections %}
+{% set not_corrected = detections[0].flux2magnitude(True) == 0 %}
+{% else %}
+{% set not_corrected = True %}
+{% endif %}
 
-
+<div class="grid grid-cols-5 gap-4 h-full">
+  <div class="col-span-1 text-center ml-3">{% include "config_panel.html.jinja" %}</div>
+  <div class="col-span-4 h-full">
     {% if not_corrected and config_state.total %}
       <div class="h-full flex items-center justify-center">
         <div class="bg-yellow-50 border border-yellow-200 rounded-md p-4 mb-4">
@@ -16,7 +15,20 @@
         </div>
       </div>
     {% else %}
+    <div id="plot-grid" class="flex flex-col gap-4 h-full">
+      <div id="lightcurve-container" class="flex-1 min-h-0">
       {% include "lightcurve.html.jinja" %}
+      </div>
+      {% if config_state.fold %}
+      <div id="periodogram-container">
+        {% if config_state.periodogram_enabled %}
+          {% include "periodogram.html.jinja" %}
+        {% endif %}
+      </div>
+      {% endif %}
+    </div>
     {% endif %}
   </div>
 </div>
+<script>
+</script>

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/periodogram.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/periodogram.html.jinja
@@ -1,0 +1,26 @@
+<div id="periodogram" style="width: 100%;height:100%;min-height:130px"></div>
+<script type="text/javascript">
+// Initialize the echarts instance based on the prepared dom
+var periodogramDom = document.getElementById('periodogram')
+var pChart = echarts.init(periodogramDom);
+var pOptions = {{ periodogram_options | tojson }};
+// we have to set the formatter here because it has to be a JavaScript function
+pOptions.tooltip.formatter = (params) => {
+  return `<b>Period:</b> ${params.data[0]} <b>Score:</b> ${params.data[1]}`;
+}
+
+// Make chart responsive
+window.addEventListener('resize', pChart.resize);
+
+// Display the chart using the configuration items and data just specified.
+pChart.setOption(pOptions);
+
+// Trigger custom event with the value of the clicked period
+pChart.on('click', function (params) {
+  const event = new CustomEvent('periodogram:periodSelected', {
+    detail: { period: params.data[0].toFixed(4) },
+    bubbles: true
+  });
+  periodogramDom.dispatchEvent(event);
+})
+</script>

--- a/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/result.py
+++ b/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/result.py
@@ -4,6 +4,7 @@ from typing import Any
 from lightcurve_api.routes.htmx.parsers import ConfigState
 
 from ...models.lightcurve import Lightcurve
+from ...models.periodogram import Periodogram
 
 
 class Result:
@@ -11,11 +12,17 @@ class Result:
     lightcurve: Lightcurve
     config_state: ConfigState
 
-    def __init__(self, echart_options: dict[str, Any], lightcurve: Lightcurve, config_state: ConfigState, period):
+    def __init__(
+        self,
+        echart_options: dict[str, Any],
+        lightcurve: Lightcurve,
+        config_state: ConfigState,
+        periodogram: Periodogram,
+    ):
         self.echart_options = echart_options
         self.lightcurve = lightcurve
         self.config_state = config_state
-        self.period = period
+        self.periodogram = periodogram
 
     def copy(self):
         return Result(
@@ -26,5 +33,5 @@ class Result:
                 forced_photometry=copy.deepcopy(self.lightcurve.forced_photometry),
             ),
             config_state=self.config_state.model_copy(deep=True),
-            period=copy.deepcopy(self.period),
+            periodogram=copy.deepcopy(self.periodogram),
         )

--- a/multisurveys-apis/src/lightcurve_api/services/period/service.py
+++ b/multisurveys-apis/src/lightcurve_api/services/period/service.py
@@ -1,18 +1,37 @@
+import copy
+import logging
 from typing import List
 
 import pandas as pd
+from toolz import curry, pipe
 
 from core.periodogram.periodogram import PeriodogramComputer
 from lightcurve_api.models.lightcurve_item import BaseDetection
 
+from ...models.periodogram import NoPeriodError, Periodogram
 from ..lightcurve_plot_service.result import Result
 
 
 def compute_periodogram(result: Result) -> Result:
-    if not result.config_state.fold:
-        return result
+    """Compute periodogram for lightcurve data and update result with period information.
 
-    if result.config_state.period > 0.05:  # if other than the default value use that
+    This function computes a periodogram using the lightcurve detections and updates
+    the result object with the computed periodogram. If the original period is set
+    to the default value (0.05), it will be replaced with the best period found.
+
+    Args:
+        result: The result object containing lightcurve data and configuration
+
+    Returns:
+        A new result object with periodogram data added
+
+    Example:
+        >>> result = Result(lightcurve=lightcurve_data, config_state=config)
+        >>> result_with_periodogram = compute_periodogram(result)
+        >>> print(result_with_periodogram.periodogram.get_best_period())
+        1.2345
+    """
+    if not result.config_state.fold:
         return result
 
     result_copy = result.copy()
@@ -20,20 +39,56 @@ def compute_periodogram(result: Result) -> Result:
     computer = PeriodogramComputer()
     df = detections2dataframe(filter_survey_detections(result.lightcurve.detections, result.config_state.survey_id))
     computed = computer.compute(df)
-    result_copy.period = computed
+    result_copy.periodogram = computed
 
-    if len(computed["best_periods_index"]) == 0:
+    try:
+        if result.config_state.period == 0.05:  # if period is the default, set the computed period
+            result_copy.config_state.period = computed.get_best_period()
+
         return result_copy
-
-    result_copy.config_state.period = round(computed["period"][computed["best_periods_index"][0]], 3)
-    return result_copy
+    except NoPeriodError:
+        logging.debug("No period found")
+        return result_copy
 
 
 def filter_survey_detections(detections: List[BaseDetection], survey_id: str) -> List[BaseDetection]:
+    """Filter detections to include only those from a specific survey.
+
+    Args:
+        detections: List of lightcurve detections
+        survey_id: The survey identifier to filter by (case-insensitive)
+
+    Returns:
+        Filtered list of detections from the specified survey
+
+    Example:
+        >>> detections = [det1, det2, det3]  # where det1.survey_id = 'ztf', det2.survey_id = 'atlas'
+        >>> filtered = filter_survey_detections(detections, 'ztf')
+        >>> len(filtered)
+        1
+    """
     return [d for d in detections if d.survey_id.lower() == survey_id.lower()]
 
 
 def detections2dataframe(detections: List[BaseDetection]):
+    """Convert a list of detections to a pandas DataFrame suitable for periodogram analysis.
+
+    The DataFrame contains columns for MJD (Modified Julian Date), brightness (magnitude),
+    brightness error, and filter ID (fid).
+
+    Total magnitude is used instead of difference, since folded lightcurve also uses corrected magnitudes.
+
+    Args:
+        detections: List of lightcurve detections
+
+    Returns:
+        DataFrame with columns: mjd, brightness, e_brightness, fid
+
+    Example:
+        >>> df = detections2dataframe(detections)
+        >>> df.columns
+        Index(['mjd', 'brightness', 'e_brightness', 'fid'], dtype='object')
+    """
     df_dict = {"mjd": [], "brightness": [], "e_brightness": [], "fid": []}
     for det in detections:
         df_dict["mjd"].append(det.mjd)
@@ -41,3 +96,109 @@ def detections2dataframe(detections: List[BaseDetection]):
         df_dict["e_brightness"].append(det.flux2magnitude_err(True))
         df_dict["fid"].append(det.band)
     return pd.DataFrame(df_dict)
+
+
+def default_echart_options():
+    """Generate default ECharts configuration options for periodogram visualization.
+
+    Returns a dictionary with pre-configured options for displaying periodogram
+    data including tooltip, grid layout, legend, and axis configurations.
+
+    Returns:
+        Dictionary with ECharts configuration options
+
+    Example:
+        >>> options = default_echart_options()
+        >>> 'xAxis' in options
+        True
+    """
+    return {
+        "tooltip": {
+            "axisPointer": {
+                "type": "cross",
+            },
+        },
+        "grid": {"left": "left", "top": "10%", "width": "75%", "height": "100%"},
+        "legend": {
+            "left": "right",
+            "top": "middle",
+            "height": "80%",
+            "orient": "vertical",
+        },
+        "xAxis": {"type": "value", "name": "period", "scale": True, "splitLine": False},
+        "yAxis": {
+            "type": "value",
+            "name": "score",
+            "scale": True,
+            "splitLine": False,
+        },
+        "series": [],
+        "animation": False,
+    }
+
+
+def get_periodogram_chart(periodogram: Periodogram) -> dict:
+    """Generate ECharts configuration for visualizing a periodogram.
+
+    Creates a complete ECharts configuration by combining default options
+    with periodogram data series for both regular periods and best periods.
+
+    Args:
+        periodogram: The periodogram data to visualize
+
+    Returns:
+        Complete ECharts configuration dictionary
+    """
+    return pipe(
+        default_echart_options(),
+        curry(add_periods_series, periodogram=periodogram),
+        curry(add_best_periods_series, periodogram=periodogram),
+    )
+
+
+def add_periods_series(options: dict, periodogram: Periodogram) -> dict:
+    """Add regular period data series to ECharts options.
+
+    Creates a scatter series for all periods in the periodogram, excluding
+    the best periods which are handled separately.
+
+    Args:
+        options: Existing ECharts configuration options
+        periodogram: Periodogram data containing periods and scores
+
+    Returns:
+        Updated ECharts options with periods series added
+
+    Note: Best periods are excluded from this series and handled separately.
+    """
+    new_options = copy.deepcopy(options)
+    new_options["series"].append({"name": "periods", "type": "scatter", "data": []})
+    for i, period in enumerate(periodogram.periods):
+        if i in periodogram.best_periods_index:
+            continue
+        new_options["series"][-1]["data"].append([period, periodogram.scores[i]])
+
+    return new_options
+
+
+def add_best_periods_series(options: dict, periodogram: Periodogram) -> dict:
+    """Add best period data series to ECharts options.
+
+    Creates a special scatter series highlighting the best periods found
+    in the periodogram analysis, using triangle symbols and red color.
+
+    Args:
+        options: Existing ECharts configuration options
+        periodogram: Periodogram data containing best periods information
+
+    Returns:
+        Updated ECharts options with best periods series added
+    """
+    new_options = copy.deepcopy(options)
+    new_options["series"].append(
+        {"name": "best periods", "type": "scatter", "data": [], "symbol": "triangle", "color": "red"}
+    )
+    for bpi in periodogram.best_periods_index:
+        new_options["series"][-1]["data"].append([periodogram.periods[bpi], periodogram.scores[bpi]])
+
+    return new_options

--- a/multisurveys-apis/src/static/main.css
+++ b/multisurveys-apis/src/static/main.css
@@ -18,20 +18,14 @@
     --color-gray-100: oklch(96.7% 0.003 264.542);
     --color-gray-200: oklch(92.8% 0.006 264.531);
     --color-gray-300: oklch(87.2% 0.01 258.338);
+    --color-gray-400: oklch(70.7% 0.022 261.325);
     --color-gray-600: oklch(44.6% 0.03 256.802);
     --color-gray-700: oklch(37.3% 0.034 259.733);
-    --color-gray-800: oklch(27.8% 0.033 256.848);
-    --color-gray-900: oklch(21% 0.034 264.665);
     --color-white: #fff;
     --spacing: 0.25rem;
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
-    --text-xl: 1.25rem;
-    --text-xl--line-height: calc(1.75 / 1.25);
-    --text-2xl: 1.5rem;
-    --text-2xl--line-height: calc(2 / 1.5);
     --font-weight-semibold: 600;
-    --font-weight-bold: 700;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --default-transition-duration: 150ms;
@@ -224,11 +218,11 @@
   .sticky {
     position: sticky;
   }
-  .col-span-2 {
-    grid-column: span 2 / span 2;
+  .col-span-1 {
+    grid-column: span 1 / span 1;
   }
-  .col-span-10 {
-    grid-column: span 10 / span 10;
+  .col-span-4 {
+    grid-column: span 4 / span 4;
   }
   .container {
     width: 100%;
@@ -275,9 +269,6 @@
   .block {
     display: block;
   }
-  .contents {
-    display: contents;
-  }
   .flex {
     display: flex;
   }
@@ -312,14 +303,14 @@
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
-  .h-\[400px\] {
-    height: 400px;
-  }
   .h-full {
     height: 100%;
   }
   .h-px {
     height: 1px;
+  }
+  .min-h-0 {
+    min-height: calc(var(--spacing) * 0);
   }
   .w-4 {
     width: calc(var(--spacing) * 4);
@@ -351,20 +342,8 @@
   .flex-1 {
     flex: 1;
   }
-  .flex-shrink {
-    flex-shrink: 1;
-  }
   .shrink {
     flex-shrink: 1;
-  }
-  .flex-grow {
-    flex-grow: 1;
-  }
-  .border-collapse {
-    border-collapse: collapse;
-  }
-  .\!transform {
-    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,) !important;
   }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
@@ -381,8 +360,11 @@
   .grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .grid-cols-12 {
-    grid-template-columns: repeat(12, minmax(0, 1fr));
+  .grid-cols-5 {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+  .flex-col {
+    flex-direction: column;
   }
   .items-center {
     align-items: center;
@@ -457,9 +439,6 @@
   .bg-yellow-50 {
     background-color: var(--color-yellow-50);
   }
-  .p-1 {
-    padding: calc(var(--spacing) * 1);
-  }
   .p-1\.5 {
     padding: calc(var(--spacing) * 1.5);
   }
@@ -472,17 +451,11 @@
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
-  .px-4 {
-    padding-inline: calc(var(--spacing) * 4);
-  }
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
   }
   .py-1\.5 {
     padding-block: calc(var(--spacing) * 1.5);
-  }
-  .py-2 {
-    padding-block: calc(var(--spacing) * 2);
   }
   .pt-1 {
     padding-top: calc(var(--spacing) * 1);
@@ -500,9 +473,6 @@
   .font-semibold {
     --tw-font-weight: var(--font-weight-semibold);
     font-weight: var(--font-weight-semibold);
-  }
-  .text-wrap {
-    text-wrap: wrap;
   }
   .text-blue-600 {
     color: var(--color-blue-600);
@@ -537,16 +507,8 @@
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
-  }
   .blur {
     --tw-blur: blur(8px);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .invert {
-    --tw-invert: invert(100%);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .filter {
@@ -692,13 +654,6 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-100);
-      }
-    }
-  }
-  .hover\:underline {
-    &:hover {
-      @media (hover: hover) {
-        text-decoration-line: underline;
       }
     }
   }
@@ -878,11 +833,6 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
-@property --tw-outline-style {
-  syntax: "*";
-  inherits: false;
-  initial-value: solid;
-}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -991,7 +941,6 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
-      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;


### PR DESCRIPTION
## Summary of the changes

- Created a new endpoint that returns a periodogram chart from the computed periodogram passed as body in the request
- The periodogram chart is standalone, but also integrated with the config panel
- Clicking the periodogram emits an event. The fold controls in the panel capture the event to update period

## Screensshots

<img width="3360" height="1338" alt="image" src="https://github.com/user-attachments/assets/6a5a7461-b071-4274-9b1e-e9500849fe60" />
