### PR TITLE
refactor: error bars as markLines instead of custom render

### DIFF
--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/lightcurve.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/lightcurve.html.jinja
@@ -23,60 +23,6 @@ mediaQuery.addListener((e) => {
     myChart.setOption(options);
 });
 
-// Register a custom series type so that it can be references as string in the chart options.
-var renderError = (_, api) => {
-  const xValue = api.value(0);
-  const highPoint = api.coord([xValue, api.value(1)]);
-  const lowPoint = api.coord([xValue, api.value(2)]);
-  const halfWidth = 1.9;
-  const style = api.style({
-    stroke: api.visual("color"),
-    fill: null,
-  });
-  return {
-    type: "group",
-    children: [
-      {
-        type: "line",
-        shape: {
-          x1: highPoint[0] - halfWidth,
-          y1: highPoint[1],
-          x2: highPoint[0] + halfWidth,
-          y2: highPoint[1],
-        },
-        style,
-      },
-      {
-        type: "line",
-        shape: {
-          x1: highPoint[0],
-          y1: highPoint[1],
-          x2: lowPoint[0],
-          y2: lowPoint[1],
-        },
-        style,
-      },
-      {
-        type: "line",
-        shape: {
-          x1: lowPoint[0] - halfWidth,
-          y1: lowPoint[1],
-          x2: lowPoint[0] + halfWidth,
-          y2: lowPoint[1],
-        },
-        style,
-      },
-    ],
-  };
-}
-echarts.registerCustomSeries('renderError', renderError);
-
-// Ensure error bars are always visible
-maxError = options.series.filter((x) => x.type == "custom").map((x) => x.data).flat().map((x) => x[2]).reduce((a, b) => Math.max(a, b), -99999)
-minError = options.series.filter((x) => x.type == "custom").map((x) => x.data).flat().map((x) => x[1]).reduce((a, b) => Math.min(a, b), 99999)
-options.yAxis.max = (maxError + 1).toFixed(0);
-options.yAxis.min = (minError - 1).toFixed(0);
-
 // Display the chart using the configuration items and data just specified.
 myChart.setOption(options);
 </script>


### PR DESCRIPTION
## Summary of the changes

- Fixes chart resize on random operations

## Observations

Error happens when using yAxis.min and yAxis.max values. Echarts calculates the size depending on these values, so it causes odd resizes sometimes.

Instead of using a custom render for the error bars, now we use markLine property which achieves similar results, but allows Echarts to set proper yAxis bounds.

## Screensshots

<img width="1615" height="793" alt="image" src="https://github.com/user-attachments/assets/5e942da3-ca65-495c-b2dc-ed406c62fce3" />
