### PR TITLE
Fixed pagination when searching object list

### DIFF
--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -94,7 +94,7 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
         stmt = stmt.order_by(*order_statement)
 
-        if order_statement is not None:
+        if len(order_statement) > 0:
             stmt = add_limits_statements(stmt, pagination_args)
 
         items = session.execute(stmt).all()

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -92,7 +92,7 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
         order_statement = create_order_statement(stmt, search_params.order_args)
 
-        stmt = stmt.order_by(order_statement)
+        stmt = stmt.order_by(*order_statement)
 
         if order_statement is not None:
             stmt = add_limits_statements(stmt, pagination_args)

--- a/multisurveys-apis/src/object_api/routes/htmx.py
+++ b/multisurveys-apis/src/object_api/routes/htmx.py
@@ -164,6 +164,9 @@ def objects_table(
             
             if oid is None and order_by is None:
                 order_by = "probability"
+            
+            if oid is not None and order_by == "oid_list":
+                order_by = None
 
             if oid is not None:
                 oid = encode_ids(survey, oid)
@@ -196,16 +199,7 @@ def objects_table(
             object_list = get_objects_list(session_ms=session, search_params=search_params)
             
             if oid is not None and order_by is None and object_list["items"] != []:
-                items = pd.DataFrame.from_records(object_list["items"])
-                items["oid"] = items["oid"].astype(str)
-                items.set_index("oid", inplace=True)
-                oid_valid = [x for x in oid if x in items.index]
-                items = items.loc[oid_valid].copy()
-                items = items.reset_index().to_dict(orient='index')
-                items = list(items.values())
-                object_list["items"] = items
-                if order_by is None:
-                    order_by = "oid_list"
+                order_by = "oid_list"
 
         else:
             object_list = {
@@ -278,6 +272,9 @@ def sidebar(
             
             if oid is None and order_by is None:
                 order_by = "probability"
+            
+            if oid is not None and order_by == "oid_list":
+                order_by = None
 
             if oid is not None:
                 oid = encode_ids(survey, oid)
@@ -306,16 +303,7 @@ def sidebar(
             object_list = get_objects_list(session_ms=session, search_params=search_params)
             
             if oid is not None and order_by is None and object_list["items"] != []:
-                items = pd.DataFrame.from_records(object_list["items"])
-                items["oid"] = items["oid"].astype(str)
-                items.set_index("oid", inplace=True)
-                oid_valid = [x for x in oid if x in items.index]
-                items = items.loc[oid_valid].copy()
-                items = items.reset_index().to_dict(orient='index')
-                items = list(items.values())
-                object_list["items"] = items
-                if order_by is None:
-                    order_by = "oid_list"
+                order_by = "oid_list"
         else:
             object_list = {
                 "next": False,

--- a/multisurveys-apis/src/object_api/routes/htmx.py
+++ b/multisurveys-apis/src/object_api/routes/htmx.py
@@ -304,6 +304,7 @@ def sidebar(
             
             if oid is not None and order_by is None and object_list["items"] != []:
                 order_by = "oid_list"
+
         else:
             object_list = {
                 "next": False,

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -26,13 +26,14 @@ def create_conesearch_statement(args):
     else:
         return True
 
-
+import pprint
 def create_order_statement(query, order_args):
     statement = None
     if order_args.order_by is None:
         return statement
     
     cols = query.column_descriptions
+
     if order_args.order_by == 'lastmjd':
         model = cols[1]["entity"]
         attr = getattr(model, order_args.order_by, None)
@@ -45,11 +46,16 @@ def create_order_statement(query, order_args):
             if attr is not None:
                 statement = attr
                 break
-    print('statement', statement, flush=True)
+    
+    second_model = cols[1]['entity']
+    second_attr = getattr(second_model, 'oid', None)
+
+
     if order_args.order_mode == "ASC":
-        statement = attr.asc()
-    elif order_args.order_mode == "DESC":
-        statement = attr.desc()
+        statement = [attr.asc(), second_attr.asc()]
+    
+    if order_args.order_mode == "DESC":
+        statement = [attr.desc(), second_attr.desc()]
 
     return statement
 

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -60,7 +60,6 @@ def get_model_attribute(cols_meta_data, order_by):
             break
 
 
-
     return statement
 
 def add_order_mode(attributes, order_mode):

--- a/multisurveys-apis/src/object_api/static/sidebar.js
+++ b/multisurveys-apis/src/object_api/static/sidebar.js
@@ -28,7 +28,7 @@ export function elementReady(selector) {
 function prepare_params(evt){
   let url = new URL(evt.detail.headers['HX-Current-URL'])
   let page = get_page(evt.detail.elt)
-  let selected_oid = evt.detail.elt.dataset.oid
+  let selected_oid = get_selected_oid(evt)
 
   url.searchParams.set("page", page)
   url.searchParams.set("selected_oid", selected_oid)
@@ -46,16 +46,26 @@ function get_page(event_element){
   return current_page
 }
 
-function prepare_data(url){
-    let dict_params = get_params_url(url)
+function get_selected_oid(evt){
+  if (evt.detail.elt.hasAttribute('data-oid')) {
+   return evt.detail.elt.dataset.oid
+  }
 
-    return  dict_params
+
+  return document.getElementById('selected_oid_cache').value
+}
+
+function prepare_data(url){
+  let dict_params = get_params_url(url)
+
+  return  dict_params
 }
 
 
 function get_params_url(url){
   let params = new URLSearchParams(url.search)
   let form_dict = {}
+
 
   params.forEach((value, key) => {
     if (key === 'oid' || key === 'n_det' || key === 'firstmjd') {

--- a/multisurveys-apis/src/object_api/templates/sidebar.html.jinja
+++ b/multisurveys-apis/src/object_api/templates/sidebar.html.jinja
@@ -6,6 +6,7 @@
 {% if objects_list['items']|length > 0 %}
 <div id="sidebar-objects-htmx" class="tw-preflight tw-text-black tw-bg-transparent dark:tw-bg-[#424242] dark:tw-text-[#EEEEEE]">
     <input id="objects-store" class="tw-hidden" data-objects="{{ objects_list['items'] }}">
+    <input id="selected_oid_cache" class="tw-hidden" value="{{selected_oid}}">
 
 
     <div class="tw-flex tw-flex-col tw-w-full tw-h-[95vh] tw-text-[0.875rem] dark:tw-bg-[#424242]">


### PR DESCRIPTION
## Summary of the changes

This PR allows searching for lists larger than the page size, keeping pagination and order. Works also when additional filters are included.


## Observations

Changes involve only the case of searching by object list (plus filters if needed). Object list sorting was moved from web-services/multisurveys-apis/src/object_api/routes/htmx.py to web-services/multisurveys-apis/src/core/repository/queries/objects.py, where also the page selection was added (since in this case the page is not given to the query input)


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [X] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.