### PR TITLE
added temporal fix to probability htmx. deleted unuseful prob from db…

### DIFF
--- a/multisurveys-apis/src/probability_api/routes/htmx.py
+++ b/multisurveys-apis/src/probability_api/routes/htmx.py
@@ -105,11 +105,10 @@ async def object_probability_app(
     classifier_list = get_classifiers(
         session_factory=request.app.state.psql_session
     )  # classifier_list es un diccionario
+    del classifier_list[2]
     class_options = [{v: v} for k, v in classifier_list.items()]
     prob_list = get_probability(oid, classifier_list, session_factory=request.app.state.psql_session)
-
     group_prob = probability_parser(prob_list)
-
     return templates.TemplateResponse(
         name="prob.html.jinja",
         context={


### PR DESCRIPTION
Temporal fix, we're receiving two classifiers, one from rubin and other from ztf and this is wrong, we must receive only the rubin one so the temporal fix is just delete the ztf one.