### PR TITLE
Fix/get stamps bug

### DIFF
--- a/multisurveys-apis/src/stamps_api/routes/rest.py
+++ b/multisurveys-apis/src/stamps_api/routes/rest.py
@@ -16,11 +16,11 @@ async def stamp(
     stamp_type: str,
     file_format: str,
     survey_id: str,
+    is_compressed: bool = True,
 ):
     handler = handler_selector(survey_id)()
-
     _, file_buffer, mime = handler.get_stamp(
-        oid, measurement_id, stamp_type, file_format
+        oid, measurement_id, stamp_type, file_format, is_compressed
     )
 
     return Response(content=file_buffer.getvalue(), media_type=mime)


### PR DESCRIPTION
We had a conflict when the file_format=fits. This part is used by the stamps card to give the compressed stamps image to the user and also is used by the client to give the fits in binary (im not sure but gives the fits file into some format in a list). So if the fits was compressed then the client failed and when the file was not compressed, the download button gave to the user a bad fits.gz (was not .gz)

So the maain idea was create the is_compressed variable. This variable decides if the fits will be compressed or not. This variable is always true, so never fails from web services until the call is from the client to the /stamps endpoint, then the call send is_compressed=false and doesnt compress the fits.

This change is automatic from the backend so the user just do the same thing but now works well.