### PR TITLE
feat(chart): multisurvey-api v25.6.183 - production stability fixes

### DIFF
--- a/charts/multisurvey_api/Chart.yaml
+++ b/charts/multisurvey_api/Chart.yaml
@@ -2,6 +2,6 @@ appVersion: 25.6.1-rc149
 description: Chart for multisurvey apis developed by ALeRCE
 name: multisurvey-api
 type: application
-version: 25.6.182
+version: 25.6.183
 
 

--- a/charts/multisurvey_api/templates/configmap.yaml
+++ b/charts/multisurvey_api/templates/configmap.yaml
@@ -9,37 +9,72 @@ data:
     {{- toYaml .Values.configYaml | nindent 4 }}
 ---
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: {{ include "service.name" . }}-nginx-conf
   namespace: {{ .Values.namespace }}
 data:
   default.conf: |
+    {{- if .Values.nginxConfig }}
+    {{- .Values.nginxConfig | nindent 4 }}
+    {{- else }}
+    upstream api_backend {
+      server 127.0.0.1:8000;
+      keepalive 16;
+      keepalive_timeout 25s;
+    }
+
     server {
       listen 80;
+
+      set_real_ip_from  10.0.0.0/8;
+      real_ip_header    X-Forwarded-For;
+      real_ip_recursive on;
+
       client_max_body_size 10M;
+      client_body_buffer_size 256k;
+
+      location = / {
+        add_header Content-Type text/plain;
+        return 200 'ok';
+      }
 
       location {{ .Values.ingress.path }}/ {
-        proxy_pass http://localhost:8000/;
-        proxy_redirect off;
-        proxy_set_header X-Forwarded-Prefix {{ .Values.ingress.path }}/;
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_pass          http://api_backend/;
+        proxy_http_version  1.1;
+        proxy_set_header    Connection          "";
+        proxy_redirect      off;
+        proxy_set_header    X-Forwarded-Prefix  {{ .Values.ingress.path }}/;
+        proxy_set_header    Host                $http_host;
+        proxy_set_header    X-Forwarded-Host    $http_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $remote_addr;
+        proxy_buffering     on;
+        proxy_buffer_size   16k;
+        proxy_buffers       8 64k;
+        proxy_busy_buffers_size 128k;
       }
 
       location {{ .Values.ingress.path }} {
-        proxy_pass http://localhost:8000/;
-        proxy_redirect off;
-        proxy_set_header X-Forwarded-Prefix {{ .Values.ingress.path }};
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-Host $http_host;
-      }
-
-      location / {
-        proxy_pass http://localhost:8000/;
+        proxy_pass          http://api_backend/;
+        proxy_http_version  1.1;
+        proxy_set_header    Connection          "";
+        proxy_redirect      off;
+        proxy_set_header    X-Forwarded-Prefix  {{ .Values.ingress.path }};
+        proxy_set_header    Host                $http_host;
+        proxy_set_header    X-Forwarded-Host    $http_host;
+        proxy_set_header    X-Real-IP           $remote_addr;
+        proxy_set_header    X-Forwarded-For     $remote_addr;
+        proxy_buffering     on;
+        proxy_buffer_size   16k;
+        proxy_buffers       8 64k;
+        proxy_busy_buffers_size 128k;
       }
 
       location /metrics {
-        proxy_pass http://localhost:8000/metrics;
+        proxy_pass         http://api_backend/metrics;
+        proxy_http_version 1.1;
+        proxy_set_header   Connection "";
       }
     }
-kind: ConfigMap
+    {{- end }}

--- a/charts/multisurvey_api/templates/deployment.yaml
+++ b/charts/multisurvey_api/templates/deployment.yaml
@@ -27,12 +27,24 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.envVariables }}
           env:
             {{- toYaml .Values.envVariables | nindent 12 }}
-          {{- end}}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: api-config
               mountPath: /app/config.yaml
@@ -48,7 +60,7 @@ spec:
           resources:
             requests:
               memory: 64M
-              cpu: 50m  
+              cpu: 50m
       volumes:
         - name: nginx-conf
           configMap:

--- a/charts/multisurvey_api/values.yaml
+++ b/charts/multisurvey_api/values.yaml
@@ -19,6 +19,11 @@ podAnnotations: {}
 
 resources: {}
 
+command: []  # override entrypoint, e.g. uvicorn with --workers
+
+readinessProbe: {}
+livenessProbe: {}
+
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -36,8 +41,6 @@ affinity:
               ## Override this value with the NodeGroup tag accordingly
               values: []
 
-nameOverride: ""
-
 service:
   type: ClusterIP
   port: 8000
@@ -46,6 +49,8 @@ configYaml:
   services: {}  # important, api port must be 8000.
 
 envVariables: {}
+
+nginxConfig: ""  # override entire nginx default.conf; if empty, chart default is used
 
 ingress:
   certificateArn: ""


### PR DESCRIPTION
Bump chart version 25.6.182 → 25.6.183

## Problem
multisurvey-api-lightcurve was experiencing Connection refused errors under load due to uvicorn running with reload=True (1 effective worker per pod). With 8 pods, entire cluster handled max 8 concurrent requests vs 1-5s avg response time, causing queue saturation.

## Chart Updates (backwards compatible)
- Added support for command override in deployment.yaml
- Added support for readinessProbe and livenessProbe in deployment.yaml
- Replaced hardcoded nginx config with production-optimized template:
  * upstream block with keepalive (16 connections, 25s timeout)
  * Real IP extraction from AWS ALB (10.0.0.0/8)
  * Proxy buffering with proper buffer sizes
  * HTTP/1.1 keepalive to upstream
  * Health check at / served by nginx (no proxy to uvicorn)
- Added nginxConfig value for full override capability
- All new values have safe defaults (command:[], probes:{}, nginxConfig:"")

## Production Impact
Fixes deployed manually to multisurvey-api-lightcurve (bypassing helm):
- 4 uvicorn workers per pod (was 1)
- Memory limits added: requests 300M, limits 700M (was 128M/unbounded)
- HPA scaled to min=4 max=8 (was min=1 max=1)
- Result: 8 healthy pods, zero connection errors, stable ~600Mi memory usage

Future helm upgrades will now use values instead of manual kubectl patches.