### PR TITLE
ms apis have gzip in nginx by default

### DIFF
--- a/charts/multisurvey_api/templates/configmap.yaml
+++ b/charts/multisurvey_api/templates/configmap.yaml
@@ -34,6 +34,13 @@ data:
       client_max_body_size 10M;
       client_body_buffer_size 256k;
 
+      gzip on;
+      gzip_proxied any;
+      gzip_comp_level 5;
+      gzip_min_length 1024;
+      gzip_types application/json text/plain text/css application/javascript;
+      gzip_vary on;
+
       location = / {
         add_header Content-Type text/plain;
         return 200 'ok';


### PR DESCRIPTION
This pull request adds gzip compression settings to the NGINX configuration in the `configmap.yaml` file. This change will help reduce the size of HTTP responses, improving load times and bandwidth usage for clients.

**NGINX configuration improvements:**

* Enabled gzip compression and configured related settings to compress HTTP responses for specific content types, including JSON, plain text, CSS, and JavaScript.