### PR TITLE
unnecessary gzip in lightcurve api, julian external dependency remove…

### DIFF
--- a/multisurveys-apis/src/lightcurve_api/api.py
+++ b/multisurveys-apis/src/lightcurve_api/api.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
 from .routes.htmx import lightcurve as htmx_lightcurve
@@ -17,8 +16,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 app.include_router(json_lightcurve.router)
 app.include_router(conesearch.router)

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja
@@ -7,7 +7,7 @@
   hx-post="{{API_URL}}/htmx/config_change"
   hx-target="#main-app"
   hx-swap="innerHTML"
-  hx-trigger="change delay:200ms"
+  hx-trigger="change"
   class="tw-max-h-fit tw-w-full"
 >
   <input type="hidden" name="oid" value="{{ config_state.oid }}">

--- a/multisurveys-apis/src/object_api/static/AstroDates.js
+++ b/multisurveys-apis/src/object_api/static/AstroDates.js
@@ -1,4 +1,4 @@
-import julian from 'https://cdn.skypack.dev/julian';;
+import julian from './julian.js';
 
 
 /**

--- a/multisurveys-apis/src/object_api/static/julian.js
+++ b/multisurveys-apis/src/object_api/static/julian.js
@@ -1,0 +1,28 @@
+// Library from https://github.com/stevebest/julian licensed under MIT License
+
+var DAY = 86400000;
+var HALF_DAY = DAY / 2;
+var UNIX_EPOCH_JULIAN_DATE = 2440587.5;
+var UNIX_EPOCH_JULIAN_DAY = 2440587;
+
+function convert(date) {
+  return (toJulianDay(date) + (toMillisecondsInJulianDay(date) / DAY)).toFixed(6);
+};
+
+function convertToDate(julian) {
+  return new Date((Number(julian) - UNIX_EPOCH_JULIAN_DATE) * DAY);
+};
+
+function toJulianDay(date) {
+  return ~~((+date + HALF_DAY) / DAY) + UNIX_EPOCH_JULIAN_DAY;
+};
+
+function toMillisecondsInJulianDay(date) {
+  return (+date + HALF_DAY) % DAY;
+};
+
+function fromJulianDayAndMilliseconds(day, ms) {
+  return (day - UNIX_EPOCH_JULIAN_DATE) * DAY + ms;
+};
+
+export default { convert, toDate: convertToDate, toJulianDay, toMillisecondsInJulianDay, fromJulianDayAndMilliseconds };

--- a/multisurveys-apis/src/static/AstroDates.js
+++ b/multisurveys-apis/src/static/AstroDates.js
@@ -1,4 +1,4 @@
-import julian from 'https://cdn.skypack.dev/julian';;
+import julian from './julian.js';
 
 
 /**

--- a/multisurveys-apis/src/static/julian.js
+++ b/multisurveys-apis/src/static/julian.js
@@ -1,0 +1,28 @@
+// Library from https://github.com/stevebest/julian licensed under MIT License
+
+var DAY = 86400000;
+var HALF_DAY = DAY / 2;
+var UNIX_EPOCH_JULIAN_DATE = 2440587.5;
+var UNIX_EPOCH_JULIAN_DAY = 2440587;
+
+function convert(date) {
+  return (toJulianDay(date) + (toMillisecondsInJulianDay(date) / DAY)).toFixed(6);
+};
+
+function convertToDate(julian) {
+  return new Date((Number(julian) - UNIX_EPOCH_JULIAN_DATE) * DAY);
+};
+
+function toJulianDay(date) {
+  return ~~((+date + HALF_DAY) / DAY) + UNIX_EPOCH_JULIAN_DAY;
+};
+
+function toMillisecondsInJulianDay(date) {
+  return (+date + HALF_DAY) % DAY;
+};
+
+function fromJulianDayAndMilliseconds(day, ms) {
+  return (day - UNIX_EPOCH_JULIAN_DATE) * DAY + ms;
+};
+
+export default { convert, toDate: convertToDate, toJulianDay, toMillisecondsInJulianDay, fromJulianDayAndMilliseconds };


### PR DESCRIPTION
This pull request makes several improvements to the codebase, mainly focused on frontend asset management and backend middleware configuration. The most significant changes are the replacement of an external dependency with a local JavaScript module for Julian date calculations, and the removal of gzip middleware from the FastAPI backend. Additionally, it modifies an HTMX trigger for improved UI responsiveness.

Dependency and asset management:

* Replaced external import of the `julian` library from Skypack CDN with a local copy (`julian.js`) in both `object_api/static` and `static` directories, ensuring the application no longer relies on an external CDN for this functionality. (`multisurveys-apis/src/object_api/static/AstroDates.js`, `multisurveys-apis/src/object_api/static/julian.js`, `multisurveys-apis/src/static/AstroDates.js`, `multisurveys-apis/src/static/julian.js`) [[1]](diffhunk://#diff-9268797ab4cc4da0b47e1c677d5a5bb825bf6c799eb94a543f8084e6316c7d1bL1-R1) [[2]](diffhunk://#diff-1a6ddbaa2d4616849477cbfb3467b4a0ef5e38282469d69a6855421ee0937185R1-R28)

Backend middleware configuration:

* Removed the `GZipMiddleware` from the FastAPI application, which disables gzip compression for API responses. This compression was redundant, as nginx sidecar has gzip compression activated. (`multisurveys-apis/src/lightcurve_api/api.py`) [[1]](diffhunk://#diff-44609bbd0463720d2939e8cf10e1b6723a7167230c1cc74da79eeac3222fafd6L3) [[2]](diffhunk://#diff-44609bbd0463720d2939e8cf10e1b6723a7167230c1cc74da79eeac3222fafd6L21-L22)

Frontend behavior:

* Changed the HTMX trigger in `config_panel.html.jinja` from `"change delay:200ms"` to `"change"`, making the UI respond immediately to changes instead of after a delay. When using a slider, it only triggers when the click is released, so no debouncing was needed.  (`multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja`)