### PR TITLE
Fixed bug in ms probability api logic when joining taxonomy and proba…

### DIFF
--- a/multisurveys-apis/src/core/repository/queries/probability.py
+++ b/multisurveys-apis/src/core/repository/queries/probability.py
@@ -11,7 +11,11 @@ def get_probability_by_oid(
     session_factory: Callable[..., AbstractContextManager[Session]] | None = None,
 ):
     with session_factory() as session:
-        stmt = select(Probability, Taxonomy).join(Taxonomy, Taxonomy.class_id == Probability.class_id)
+        stmt = select(Probability, Taxonomy).join(
+            Taxonomy,
+            (Taxonomy.class_id == Probability.class_id)
+            & (Taxonomy.classifier_id == Probability.classifier_id),
+        )
 
         if classifier_id:
             stmt = stmt.where(

--- a/multisurveys-apis/src/core/repository/queries/probability.py
+++ b/multisurveys-apis/src/core/repository/queries/probability.py
@@ -13,8 +13,7 @@ def get_probability_by_oid(
     with session_factory() as session:
         stmt = select(Probability, Taxonomy).join(
             Taxonomy,
-            (Taxonomy.class_id == Probability.class_id)
-            & (Taxonomy.classifier_id == Probability.classifier_id),
+            (Taxonomy.class_id == Probability.class_id) & (Taxonomy.classifier_id == Probability.classifier_id),
         )
 
         if classifier_id:


### PR DESCRIPTION
This pull request updates the join condition in the `get_probability_by_oid` function to ensure that the join between the `Probability` and `Taxonomy` tables includes both `class_id` and `classifier_id` in the join criteria. Otherwise, when more than one classifier is present in the DB, the api returns an incorrect output