### PR TITLE
Fix query and parser of classifiers

### DIFF
--- a/multisurveys-apis/src/classifier_api/services/parsers.py
+++ b/multisurveys-apis/src/classifier_api/services/parsers.py
@@ -1,5 +1,6 @@
 from ..models.classifiers import Classifiers
 
+
 def parse_classifiers(classifier_data: list) -> list:
     """
     Parses the classifiers data from the database response into a list of Classifiers models.

--- a/multisurveys-apis/src/classifier_api/services/parsers.py
+++ b/multisurveys-apis/src/classifier_api/services/parsers.py
@@ -1,6 +1,5 @@
 from ..models.classifiers import Classifiers
 
-import pprint
 def parse_classifiers(classifier_data: list) -> list:
     """
     Parses the classifiers data from the database response into a list of Classifiers models.

--- a/multisurveys-apis/src/classifier_api/services/parsers.py
+++ b/multisurveys-apis/src/classifier_api/services/parsers.py
@@ -1,6 +1,6 @@
 from ..models.classifiers import Classifiers
 
-
+import pprint
 def parse_classifiers(classifier_data: list) -> list:
     """
     Parses the classifiers data from the database response into a list of Classifiers models.
@@ -15,16 +15,14 @@ def parse_classifiers(classifier_data: list) -> list:
     parsed_classifiers = []
 
     for row in classifier_data:
-        classifier_dict = row[0].__dict__.copy()
-        taxonomy_dict = row[1].__dict__.copy()
-        classifier_name = classifier_dict["classifier_name"]
-        classifier_id = classifier_dict["classifier_id"]
-        class_name = taxonomy_dict["class_name"]
+        classifier_name = row["classifier_name"]
+        classifier_id = row["classifier_id"]
+        class_name = row["class_name"]
 
         if classifier_name not in grouped_classifiers.keys():
             grouped_classifiers[classifier_name] = {
                 "classifier_name": classifier_name,
-                "classifier_version": classifier_dict["classifier_version"],
+                "classifier_version": row["classifier_version"],
                 "classes": [class_name],
                 "classifier_id": classifier_id,
             }

--- a/multisurveys-apis/src/core/repository/queries/classifiers.py
+++ b/multisurveys-apis/src/core/repository/queries/classifiers.py
@@ -47,15 +47,24 @@ def get_all_classifiers(
     """
     with session_factory() as session:
         stmt = (
-            select(Classifier, Taxonomy)
+            select(
+                Classifier.classifier_id,
+                Classifier.classifier_name,
+                Classifier.tid,
+                Classifier.classifier_version,
+                Taxonomy.classifier_id.label("taxonomy_classifier_id"),
+                Taxonomy.order,
+                Taxonomy.class_name,
+                Taxonomy.class_id
+            )
             .join(
                 Taxonomy,
                 Classifier.classifier_id == Taxonomy.classifier_id,
             )
-            .where(Classifier.tid == 1)  # 1 = lsst
+            .where(Classifier.tid == 1)
             .order_by(Classifier.classifier_name.asc(), Taxonomy.order.asc())
         )
         result = session.execute(stmt)
-        result = result.all()
+        result = result.mappings().all()
 
         return result

--- a/multisurveys-apis/src/core/repository/queries/classifiers.py
+++ b/multisurveys-apis/src/core/repository/queries/classifiers.py
@@ -61,7 +61,7 @@ def get_all_classifiers(
                 Taxonomy,
                 Classifier.classifier_id == Taxonomy.classifier_id,
             )
-            .where(Classifier.tid == 1)
+            .where(Classifier.tid == 1)  # 1 = lsst
             .order_by(Classifier.classifier_name.asc(), Taxonomy.order.asc())
         )
         result = session.execute(stmt)

--- a/multisurveys-apis/src/core/repository/queries/classifiers.py
+++ b/multisurveys-apis/src/core/repository/queries/classifiers.py
@@ -55,7 +55,7 @@ def get_all_classifiers(
                 Taxonomy.classifier_id.label("taxonomy_classifier_id"),
                 Taxonomy.order,
                 Taxonomy.class_name,
-                Taxonomy.class_id
+                Taxonomy.class_id,
             )
             .join(
                 Taxonomy,

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -6,6 +6,7 @@ from db_plugins.db.sql.models import (
 )
 from sqlalchemy.orm import aliased
 from sqlalchemy import select, and_
+from sqlalchemy.dialects import postgresql  
 from object_api.services.parsers import serialize_items
 from object_api.services.statements_sql import (
     create_order_statement,
@@ -88,13 +89,13 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
         order_statement = create_order_statement(stmt, search_params.order_args)
 
-        stmt = stmt.order_by(*order_statement)
+        stmt = stmt.order_by(*order_statement)# o el dialecto que uses
 
         if len(order_statement) > 0:
             stmt = add_limits_statements(stmt, pagination_args)
 
         items = session.execute(stmt).all()
-
+        
         if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
             items = sort_by_oid_list_and_select_page(search_params, items)
 

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -15,7 +15,6 @@ from object_api.services.statements_sql import (
 from object_api.models.pagination import Pagination
 
 
-
 class ObjectsModels:
     def __init__(self, survey):
         self.survey = survey
@@ -95,7 +94,7 @@ def query_get_objects(session_ms, search_params, parsed_params):
             stmt = add_limits_statements(stmt, pagination_args)
 
         items = session.execute(stmt).all()
-        
+
         if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
             items = sort_by_oid_list_and_select_page(search_params, items)
 

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -1,3 +1,4 @@
+import pandas as pd
 from db_plugins.db.sql.models import (
     Object,
     ZtfObject,
@@ -6,14 +7,13 @@ from db_plugins.db.sql.models import (
 )
 from sqlalchemy.orm import aliased
 from sqlalchemy import select, and_
-from sqlalchemy.dialects import postgresql  
 from object_api.services.parsers import serialize_items
 from object_api.services.statements_sql import (
     create_order_statement,
     add_limits_statements,
 )
 from object_api.models.pagination import Pagination
-import pandas as pd
+
 
 
 class ObjectsModels:
@@ -89,7 +89,7 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
         order_statement = create_order_statement(stmt, search_params.order_args)
 
-        stmt = stmt.order_by(*order_statement)# o el dialecto que uses
+        stmt = stmt.order_by(*order_statement)
 
         if len(order_statement) > 0:
             stmt = add_limits_statements(stmt, pagination_args)

--- a/multisurveys-apis/src/core/repository/queries/probability.py
+++ b/multisurveys-apis/src/core/repository/queries/probability.py
@@ -1,7 +1,7 @@
 from typing import Callable
 from contextlib import AbstractContextManager
 from db_plugins.db.sql.models import Taxonomy, Probability
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 from sqlalchemy import select
 
 
@@ -11,9 +11,12 @@ def get_probability_by_oid(
     session_factory: Callable[..., AbstractContextManager[Session]] | None = None,
 ):
     with session_factory() as session:
-        stmt = select(Probability, Taxonomy).join(
-            Taxonomy,
-            (Taxonomy.class_id == Probability.class_id) & (Taxonomy.classifier_id == Probability.classifier_id),
+        TaxonomyAlias = aliased(Taxonomy, flat=True)
+
+        stmt = select(Probability, TaxonomyAlias).join(
+            TaxonomyAlias,
+            (TaxonomyAlias.class_id == Probability.class_id) & 
+            (TaxonomyAlias.classifier_id == Probability.classifier_id),
         )
 
         if classifier_id:
@@ -24,7 +27,7 @@ def get_probability_by_oid(
         else:
             stmt = stmt.where(Probability.oid == oid)
 
-        stmt = stmt.order_by(Taxonomy.order.asc())
+        stmt = stmt.order_by(TaxonomyAlias.order.asc())
 
         result = session.execute(stmt).all()
         return result

--- a/multisurveys-apis/src/core/repository/queries/probability.py
+++ b/multisurveys-apis/src/core/repository/queries/probability.py
@@ -15,8 +15,8 @@ def get_probability_by_oid(
 
         stmt = select(Probability, TaxonomyAlias).join(
             TaxonomyAlias,
-            (TaxonomyAlias.class_id == Probability.class_id) & 
-            (TaxonomyAlias.classifier_id == Probability.classifier_id),
+            (TaxonomyAlias.class_id == Probability.class_id)
+            & (TaxonomyAlias.classifier_id == Probability.classifier_id),
         )
 
         if classifier_id:

--- a/multisurveys-apis/src/object_api/models/object.py
+++ b/multisurveys-apis/src/object_api/models/object.py
@@ -268,7 +268,7 @@ class LsstObjectProbability(BaseModel):
     stellar: bool | None = None
     class_name: str | None = None
     classifier_name: str | None = None
-    classfier_version: str | None = None
+    classifier_version: str | None = None
     probability: float | None = None
     ranking: int | None = None
 

--- a/multisurveys-apis/src/object_api/routes/rest.py
+++ b/multisurveys-apis/src/object_api/routes/rest.py
@@ -59,9 +59,7 @@ def list_objects(
         )
 
         conesearch = Consearch(dec=dec, ra=ra, radius=radius)
-
         pagination = PaginationArgs(page=page, page_size=page_size, count=count)
-
         order = Order(order_by=order_by, order_mode=order_mode)
 
         search_params = SearchParams(

--- a/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
+++ b/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
@@ -26,6 +26,7 @@ def update_filters(search_params, classes_list):
 
     return search_params
 
+
 def match_and_update_item_class(items, classes_list):
     for item in items:
         matched_class = find_match_class(item, classes_list)
@@ -34,26 +35,29 @@ def match_and_update_item_class(items, classes_list):
             item["class_name"] = matched_class["class_name"]
             item["classifier_name"] = matched_class["classifier_name"]
             item["classifier_version"] = matched_class["classifier_version"]
-        
+
         item["classifier_version"] = str(item["classifier_version"])
 
     return items
+
 
 def find_match_class(item, classes_list):
     for class_data in classes_list:
         if check_classifier_match(item, class_data) and check_class_match(item, class_data):
             return class_data
-        
+
     return None
+
 
 def check_classifier_match(item, class_data):
     if item["classifier_id"] == class_data["classifier_id"]:
         return True
-    
+
     return False
+
 
 def check_class_match(item, class_data):
     if item["class_id"] == class_data["class_id"]:
         return True
-    
+
     return False

--- a/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
+++ b/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
@@ -34,6 +34,8 @@ def match_and_update_item_class(items, classes_list):
             item["class_name"] = matched_class["class_name"]
             item["classifier_name"] = matched_class["classifier_name"]
             item["classifier_version"] = matched_class["classifier_version"]
+        
+        item["classifier_version"] = str(item["classifier_version"])
 
     return items
 

--- a/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
+++ b/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
@@ -26,13 +26,32 @@ def update_filters(search_params, classes_list):
 
     return search_params
 
-
 def match_and_update_item_class(items, classes_list):
     for item in items:
-        for class_data in classes_list:
-            if item["class_id"] == class_data["class_id"]:
-                item["class_name"] = class_data["class_name"]
-                item["classifier_name"] = class_data["classifier_name"]
-                break
+        matched_class = find_match_class(item, classes_list)
+
+        if matched_class != None:
+            item["class_name"] = matched_class["class_name"]
+            item["classifier_name"] = matched_class["classifier_name"]
+            item["classifier_version"] = matched_class["classifier_version"]
 
     return items
+
+def find_match_class(item, classes_list):
+    for class_data in classes_list:
+        if check_classifier_match(item, class_data) and check_class_match(item, class_data):
+            return class_data
+        
+    return None
+
+def check_classifier_match(item, class_data):
+    if item["classifier_id"] == class_data["classifier_id"]:
+        return True
+    
+    return False
+
+def check_class_match(item, class_data):
+    if item["class_id"] == class_data["class_id"]:
+        return True
+    
+    return False

--- a/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
+++ b/multisurveys-apis/src/object_api/services/classifier_data_matcher.py
@@ -30,7 +30,7 @@ def match_and_update_item_class(items, classes_list):
     for item in items:
         matched_class = find_match_class(item, classes_list)
 
-        if matched_class != None:
+        if matched_class is not None:
             item["class_name"] = matched_class["class_name"]
             item["classifier_name"] = matched_class["classifier_name"]
             item["classifier_version"] = matched_class["classifier_version"]

--- a/multisurveys-apis/src/object_api/services/classifiers_utils.py
+++ b/multisurveys-apis/src/object_api/services/classifiers_utils.py
@@ -15,6 +15,7 @@ def sort_classifiers(classifiers):
     ## classifier_id:priority
     priorities = {
         1: 0,
+        3: 1,
     }
 
     # insertar por prioridad

--- a/multisurveys-apis/src/object_api/services/object_services.py
+++ b/multisurveys-apis/src/object_api/services/object_services.py
@@ -21,6 +21,7 @@ def get_object_by_id(oid, survey_id: str, session_ms, return_survey_extra: bool 
     response = parse_unique_object_query(object_model, survey_id, return_survey_extra)
     return response
 
+
 def get_objects_list(session_ms, search_params):
     classes_list = get_classes_list(session_ms)
     search_params = update_filters(search_params, classes_list)

--- a/multisurveys-apis/src/object_api/services/object_services.py
+++ b/multisurveys-apis/src/object_api/services/object_services.py
@@ -21,7 +21,6 @@ def get_object_by_id(oid, survey_id: str, session_ms, return_survey_extra: bool 
     response = parse_unique_object_query(object_model, survey_id, return_survey_extra)
     return response
 
-
 def get_objects_list(session_ms, search_params):
     classes_list = get_classes_list(session_ms)
     search_params = update_filters(search_params, classes_list)

--- a/multisurveys-apis/src/object_api/services/parsers.py
+++ b/multisurveys-apis/src/object_api/services/parsers.py
@@ -99,7 +99,6 @@ def serialize_items(data):
 
     return ret
 
-
 def parse_items_probabilities(items, survey):
     ret = []
     for item in items:

--- a/multisurveys-apis/src/object_api/services/parsers.py
+++ b/multisurveys-apis/src/object_api/services/parsers.py
@@ -67,7 +67,6 @@ def parse_unique_object_query(sql_response, survey, return_survey_extra=False):
 
     return model_parsed
 
-
 def parse_objects_list_output(result, survey, classes_list):
     items = serialize_items(result.items_page)
     items_updated = match_and_update_item_class(items, classes_list)
@@ -109,14 +108,10 @@ def parse_items_probabilities(items, survey):
 
     return ret
 
-
 def parse_classifiers(classes_list):
     res = []
     for class_name in classes_list:
-        classifier_ms = jsonable_encoder(class_name[0], exclude={"_sa_instance_state"})
-        taxonomy_ms = jsonable_encoder(class_name[1], exclude={"_sa_instance_state"})
-        merged_dict = {**classifier_ms, **taxonomy_ms}
-
+        merged_dict = {**class_name}
         res.append(merged_dict)
 
     return res

--- a/multisurveys-apis/src/object_api/services/parsers.py
+++ b/multisurveys-apis/src/object_api/services/parsers.py
@@ -67,6 +67,7 @@ def parse_unique_object_query(sql_response, survey, return_survey_extra=False):
 
     return model_parsed
 
+
 def parse_objects_list_output(result, survey, classes_list):
     items = serialize_items(result.items_page)
     items_updated = match_and_update_item_class(items, classes_list)
@@ -99,6 +100,7 @@ def serialize_items(data):
 
     return ret
 
+
 def parse_items_probabilities(items, survey):
     ret = []
     for item in items:
@@ -106,6 +108,7 @@ def parse_items_probabilities(items, survey):
         ret.append(model_output)
 
     return ret
+
 
 def parse_classifiers(classes_list):
     res = []

--- a/multisurveys-apis/src/object_api/static/object.css
+++ b/multisurveys-apis/src/object_api/static/object.css
@@ -1087,6 +1087,10 @@
   overflow-wrap: break-word;
 }
 
+.tw-preflight .tw-break-all{
+  word-break: break-all;
+}
+
 .tw-preflight .tw-rounded{
   border-radius: 0.25rem;
 }
@@ -2809,6 +2813,10 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
 
   .tw-preflight .sm\:tw-w-full{
     width: 100%;
+  }
+
+  .tw-preflight .sm\:tw-w-\[160px\]{
+    width: 160px;
   }
 
   .tw-preflight .sm\:tw-max-w-\[80\%\]{

--- a/multisurveys-apis/src/object_api/templates/main_table_objects/objects_table.html.jinja
+++ b/multisurveys-apis/src/object_api/templates/main_table_objects/objects_table.html.jinja
@@ -211,19 +211,43 @@
                     ...send_order_data("deltamjd", "{{actual_order_mode}}")}'
                     >
                     
-                    <div id="delta_mjd" class="tw-group tw-flex tw-items-center tw-gap-1.5 tw-cursor-pointer">
-                        <span class="placeholder-span">
-                            DeltaMJD (days)
-                        </span>
-                        <svg
-                            name="sort_arrow"
-                            data-direction="{% if actual_order_by == 'deltamjd' %}{{ 'down' if actual_order_mode == 'DESC' else 'up' }}{% else %}down{% endif %}"
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="{% if actual_order_by == 'deltamjd' %}tw-visible{% else %}tw-invisible group-hover:tw-visible{% endif %} tw-h-4 tw-w-4 tw-fill-black dark:tw-fill-white"
-                            viewBox="0 -960 960 960"
-                            fill="#e3e3e3">
-                            <path d="{% if actual_order_by == 'deltamjd' and actual_order_mode == 'ASC' %}M440-160v-487L216-423l-56-57 320-320 320 320-56 57-224-224v487h-80Z{% else %}M440-800v487L216-537l-56 57 320 320 320-320-56-57-224 224v-487h-80Z{% endif %}"/>
-                        </svg>
+                        <div id="delta_mjd" class="tw-group tw-flex tw-items-center tw-gap-1.5 tw-cursor-pointer">
+                            <span class="placeholder-span">
+                                DeltaMJD (days)
+                            </span>
+                            <svg
+                                name="sort_arrow"
+                                data-direction="{% if actual_order_by == 'deltamjd' %}{{ 'down' if actual_order_mode == 'DESC' else 'up' }}{% else %}down{% endif %}"
+                                xmlns="http://www.w3.org/2000/svg"
+                                class="{% if actual_order_by == 'deltamjd' %}tw-visible{% else %}tw-invisible group-hover:tw-visible{% endif %} tw-h-4 tw-w-4 tw-fill-black dark:tw-fill-white"
+                                viewBox="0 -960 960 960"
+                                fill="#e3e3e3">
+                                <path d="{% if actual_order_by == 'deltamjd' and actual_order_mode == 'ASC' %}M440-160v-487L216-423l-56-57 320-320 320 320-56 57-224-224v487h-80Z{% else %}M440-800v487L216-537l-56 57 320 320 320-320-56-57-224 224v-487h-80Z{% endif %}"/>
+                            </svg>
+                        </div>
+                    </th>
+                    <th 
+                    id="classifier_column"
+                    name="object_column_name"
+                    class="tw-px-4 hover:tw-bg-[#b2b2b2] hover:tw-cursor-pointer"
+                    >
+                        <div id="classifier" class="tw-group tw-flex tw-items-center tw-gap-1.5 tw-cursor-pointer">
+                            <span class="placeholder-span">
+                                Classifier
+                            </span>
+                        </div>
+                    </th>
+                    <th 
+                    id="classifier_version_column"
+                    name="object_column_name"
+                    class="tw-px-4 hover:tw-bg-[#b2b2b2] hover:tw-cursor-pointer"
+                    >
+                        <div id="classifier_version" class="tw-group tw-flex tw-items-center tw-gap-1.5 tw-cursor-pointer">
+                            <span class="placeholder-span">
+                                Classifier Version
+                            </span>
+                        </div>
+                    </th>
                 </tr>
             </thead>
             <tbody class="tw-text-[0.875rem] tw-text-black dark:tw-text-white">
@@ -266,6 +290,15 @@
                         <td class="tw-px-4 tw-h-[48px] tw-flex tw-justify-between tw-items-center sm:tw-table-cell sm:tw-h-[32px]">
                             <span class="tw-font-semibold sm:tw-hidden">DeltaMJD (days)</span>
                             <span name="deltamjd">{{"%.3f" | format(item['deltamjd'])}}</span>
+                        </td>
+                        
+                        <td class="tw-px-4 tw-h-[48px] tw-flex tw-justify-between tw-items-center sm:tw-table-cell sm:tw-h-[32px]">
+                            <span class="tw-font-semibold sm:tw-hidden">Classifier</span>
+                            <span name="classifier">{{item['classifier_name']}}</span>
+                        </td>
+                        <td class="tw-px-4 tw-h-[48px] tw-flex tw-justify-between tw-items-center sm:tw-table-cell sm:tw-h-[32px]">
+                            <span class="tw-font-semibold sm:tw-hidden">Classifier</span>
+                            <span name="classifier">{{item['classifier_version']}}</span>
                         </td>
                     </tr>
                 {% endfor %}

--- a/multisurveys-apis/src/object_api/templates/main_table_objects/objects_table.html.jinja
+++ b/multisurveys-apis/src/object_api/templates/main_table_objects/objects_table.html.jinja
@@ -297,8 +297,8 @@
                             <span name="classifier" class="">{{item['classifier_name'] | replace('_', ' ') }}</span>
                         </td>
                         <td class="tw-px-4 tw-h-[48px] tw-flex tw-justify-between tw-items-center sm:tw-table-cell sm:tw-h-[32px]">
-                            <span class="tw-font-semibold sm:tw-hidden">Classifier</span>
-                            <span name="classifier">{{item['classifier_version']}}</span>
+                            <span class="tw-font-semibold sm:tw-hidden">Classifier version</span>
+                            <span name="classifier_version">{{item['classifier_version']}}</span>
                         </td>
                     </tr>
                 {% endfor %}

--- a/multisurveys-apis/src/object_api/templates/main_table_objects/objects_table.html.jinja
+++ b/multisurveys-apis/src/object_api/templates/main_table_objects/objects_table.html.jinja
@@ -294,7 +294,7 @@
                         
                         <td class="tw-px-4 tw-h-[48px] tw-flex tw-justify-between tw-items-center sm:tw-table-cell sm:tw-h-[32px]">
                             <span class="tw-font-semibold sm:tw-hidden">Classifier</span>
-                            <span name="classifier">{{item['classifier_name']}}</span>
+                            <span name="classifier" class="">{{item['classifier_name'] | replace('_', ' ') }}</span>
                         </td>
                         <td class="tw-px-4 tw-h-[48px] tw-flex tw-justify-between tw-items-center sm:tw-table-cell sm:tw-h-[32px]">
                             <span class="tw-font-semibold sm:tw-hidden">Classifier</span>

--- a/multisurveys-apis/src/probability_api/routes/htmx.py
+++ b/multisurveys-apis/src/probability_api/routes/htmx.py
@@ -106,6 +106,7 @@ def sort_classifiers(classifiers):
     ## classifier_id:priority
     priorities = {
         1: 0,
+        3:1,
     }
 
     sorted_items = sorted(

--- a/multisurveys-apis/src/probability_api/routes/htmx.py
+++ b/multisurveys-apis/src/probability_api/routes/htmx.py
@@ -106,7 +106,7 @@ def sort_classifiers(classifiers):
     ## classifier_id:priority
     priorities = {
         1: 0,
-        3:1,
+        3: 1,
     }
 
     sorted_items = sorted(

--- a/multisurveys-apis/src/probability_api/services/parser.py
+++ b/multisurveys-apis/src/probability_api/services/parser.py
@@ -37,9 +37,7 @@ def parse_classifiers(classifiers_data):
         list: List of classifier IDs.
     """
     parsed_classifiers = {}
-
     for row in classifiers_data:
-        model_dict = row[0].__dict__.copy()
-        parsed_classifiers[model_dict["classifier_id"]] = model_dict["classifier_name"]
+        parsed_classifiers[row["classifier_id"]] = row["classifier_name"]
 
     return parsed_classifiers

--- a/multisurveys-apis/src/probability_api/services/parser.py
+++ b/multisurveys-apis/src/probability_api/services/parser.py
@@ -13,16 +13,21 @@ def parse_probability(probability_data, classifiers):
     """
     parsed_probability = []
 
-    for row in probability_data:
-        probability_dict = row[0].__dict__.copy()
-        taxonomy_list = row[1].__dict__.copy()
+    for probability, taxonomy in probability_data:
+        model_dict = {
+            "oid": probability.oid,
+            "class_id": probability.class_id,
+            "classifier_id": probability.classifier_id,
+            "probability": probability.probability,
+            "ranking": probability.ranking,
+            "class_name": taxonomy.class_name,
+            "classifier_name": classifiers[probability.classifier_id],
+            "classifier_version": probability.classifier_version,
+        }
 
-        model_dict = {**probability_dict, **taxonomy_list}
-        model_dict["classifier_name"] = classifiers[model_dict["classifier_id"]]
+        parsed_probability.append(Probability(**model_dict))
 
-        model_parsed = Probability(**model_dict)
-        parsed_probability.append(model_parsed)
-
+    
     return parsed_probability
 
 

--- a/multisurveys-apis/src/probability_api/services/parser.py
+++ b/multisurveys-apis/src/probability_api/services/parser.py
@@ -27,7 +27,6 @@ def parse_probability(probability_data, classifiers):
 
         parsed_probability.append(Probability(**model_dict))
 
-    
     return parsed_probability
 
 


### PR DESCRIPTION
## Summary of the changes

Fix the sqlAlchemy query, the problem was that the ORM used the wrong classifier id to make the match.

Fix the parser of the items results, there was a missing condition to identify the classifier in the parser of the items, now are two conditions:
  1. match with classifier id.
  2. match with class id.


## Observations

<-- Add some notes to keep in mind !-->


## If the change is BREAKING, please give more details about the breaking changes

<-- What change breaks what and how !-->

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->