### PR TITLE
fix(lightcurve): manage flux when its zero

### DIFF
--- a/multisurveys-apis/src/lightcurve_api/models/detections.py
+++ b/multisurveys-apis/src/lightcurve_api/models/detections.py
@@ -310,17 +310,21 @@ class LsstDetection(BaseDetection):
             d = Distance(REDSHIFT, unit=u.lyr)  # type: ignore
             flux = self.scienceFlux if total else self.psfFlux
 
+            if flux == 0:
+                raise ZeroDivisionError("Flux cannot be zero")
+
+            if flux < 0:
+                raise ValueError("Flux no puede ser negativo para cálculo de magnitud")
+
             if flux < 0:
                 flux = math.fabs(flux)
                 if total:
                     flux = flux * -1
 
-            if flux < 0:
-                raise ValueError("Flux no puede ser negativo para cálculo de magnitud")
 
             mag = 31.4 - 2.5 * math.log10(flux)
 
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
             traceback.print_exc()
             return 0
 
@@ -339,6 +343,9 @@ class LsstDetection(BaseDetection):
             flux = self.scienceFlux if total else self.psfFlux
             flux_err = self.scienceFluxErr if total else self.psfFluxErr
 
+            if flux == 0:
+                raise ZeroDivisionError("Flux cannot be zero")
+
             if flux < 0:
                 flux = math.fabs(flux)
 
@@ -347,7 +354,7 @@ class LsstDetection(BaseDetection):
 
             magnitude_error = (2.5 * flux_err) / (math.log(10.0) * flux)
 
-        except ValueError:
+        except (ValueError, ZeroDivisionError):
             traceback.print_exc()
             return 0
 

--- a/multisurveys-apis/src/lightcurve_api/models/detections.py
+++ b/multisurveys-apis/src/lightcurve_api/models/detections.py
@@ -321,7 +321,6 @@ class LsstDetection(BaseDetection):
                 if total:
                     flux = flux * -1
 
-
             mag = 31.4 - 2.5 * math.log10(flux)
 
         except (ValueError, ZeroDivisionError):


### PR DESCRIPTION
## Summary of the changes

Add a new catch for ZeroDivisionError, there was a case when flux is zero in lightcurve detections.


## Observations

<-- Add some notes to keep in mind !-->


## If the change is BREAKING, please give more details about the breaking changes

<-- What change breaks what and how !-->

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->