### PR TITLE
fix(lightcurve): render negative difference-flux LSST detections

### DIFF
--- a/multisurveys-apis/src/lightcurve_api/models/detections.py
+++ b/multisurveys-apis/src/lightcurve_api/models/detections.py
@@ -314,9 +314,6 @@ class LsstDetection(BaseDetection):
                 raise ZeroDivisionError("Flux cannot be zero")
 
             if flux < 0:
-                raise ValueError("Flux no puede ser negativo para cálculo de magnitud")
-
-            if flux < 0:
                 flux = math.fabs(flux)
                 if total:
                     flux = flux * -1

--- a/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/service.py
+++ b/multisurveys-apis/src/lightcurve_api/services/lightcurve_plot_service/service.py
@@ -376,9 +376,6 @@ def _get_min_and_max_errors(echarts_options: dict[str, Any]) -> List:
             limits_error_plots_series.append(serie["min_plot_error"])
             limits_error_plots_series.append(serie["max_plot_error"])
 
-    if not limits_error_plots_series:
-        raise ValueError("No error bars found in any series")
-
     return limits_error_plots_series
 
 


### PR DESCRIPTION
## Problem

`https://api-lsst.alerce.online/lightcurve_api/htmx/lightcurve?oid=170455190790473103&survey_id=lsst` returned **HTTP 500**, and the lightcurve plot was empty for LSST objects whose only detection(s) have **negative difference flux** (`isNegative=True`, e.g. `psfFlux=-3182.65`).

## Root cause

`LsstDetection.flux2magnitude` raised `ValueError` on negative flux. For a negative-difference-flux object this meant:
- the detection's magnitude fell back to `0` and was filtered out by `_valid_point` (empty plot), and
- no error-bar series were produced, so `_get_min_and_max_errors` hit `raise ValueError("No error bars found in any series")` → unhandled **500**.

Negative **difference** flux is normal and physically meaningful (a relative dip vs. template); it should be plotted via `abs()` then `log10`. The abs-handling branch already existed but had been made unreachable by a premature `raise`.

## Changes

- **`detections.py`** — remove the premature `raise` so negative difference flux falls through to `abs()` + `log10`, yielding a valid magnitude (e.g. `−3182.65 → 22.64`). Total/apparent flux still returns `0` for negatives, since apparent magnitude is genuinely undefined there.
- **`service.py`** — drop the `No error bars found in any series` raise in the y-axis limits helper; return an empty list instead so the chart renders without auto-computed limit lines (matches the existing no-limits path). Defensive: this raise 500'd for any object that legitimately yields no error-bar series (non-detection-only / forced-photometry-only / all-filtered views).

## Verification

Ran the API locally against the production read DB. Both objects now return **200** and render their detections in the default magnitude view:
- `170455190790473103` (negative-flux, originally 500) → `det LSST: r` point at `[61187.396, 22.643]` ✓
- `170433140619739440` (control) → unaffected ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)