### PR TITLE
fix(lightcurve): serve static files behind the prefix-stripping proxy

### DIFF
--- a/multisurveys-apis/pyproject.toml
+++ b/multisurveys-apis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "multisurveys-apis"
-version = "0.2.0"
+version = "0.2.2"
 description = ""
 authors = ["Demurest <eric.apolonio@hotmail.com>"]
 readme = "README.md"

--- a/multisurveys-apis/src/lightcurve_api/api.py
+++ b/multisurveys-apis/src/lightcurve_api/api.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -53,7 +53,7 @@ TAGS_METADATA = [
 app = FastAPI(
     root_path="/lightcurve_api",
     title="ALeRCE Lightcurve API",
-    version="0.2.0",
+    version="0.2.2",
     description=API_DESCRIPTION,
     openapi_tags=TAGS_METADATA,
     contact={"name": "ALeRCE", "url": "https://alerce.science"},
@@ -73,8 +73,17 @@ app.include_router(json_lightcurve.router, tags=["Photometry"])
 app.include_router(conesearch.router, tags=["Cone search"])
 app.include_router(htmx_lightcurve.router, tags=["Browser UI (HTMX)"])
 
-app.mount(
-    "/static",
-    StaticFiles(directory="src/static"),
-    name="static",
-)
+# Static files are served via an explicit route rather than app.mount() because
+# the app sets root_path="/lightcurve_api" while the nginx sidecar strips that
+# prefix before forwarding. A StaticFiles *mount* resolves files against the
+# accumulated root_path ("/lightcurve_api/static"), so the stripped path
+# "/static/..." that actually arrives never matches and 404s. A normal route
+# matches on the post-strip path (like the other routers do); delegating to
+# StaticFiles.get_response keeps ETag/Last-Modified, conditional 304s, Range
+# requests, HEAD and traversal-safe lookups.
+_static = StaticFiles(directory="src/static")
+
+
+@app.get("/static/{path:path}", name="static", include_in_schema=False)
+async def static_files(path: str, request: Request):
+    return await _static.get_response(path, request.scope)


### PR DESCRIPTION
## Problem
After enabling OpenAPI docs (#547), the lightcurve API sets `root_path="/lightcurve_api"`. The nginx sidecar strips that prefix before forwarding, so requests arrive as `/static/...`. A Starlette `StaticFiles` **mount** resolves files against the *accumulated* root_path (`/lightcurve_api/static`), so the stripped path never matches → **every static asset 404s** in production, e.g.:

```
https://api-lsst.alerce.online/lightcurve_api/static/lightcurve.css  -> 404
```

The htmx page and `/docs` work because normal routes match on the already-stripped route path; only the mount was affected.

## Fix
Replace the `app.mount("/static", ...)` with an explicit route that matches on the post-strip path (like the other routers) and delegates to `StaticFiles.get_response`. This keeps ETag/Last-Modified, conditional 304s, Range requests, HEAD, and traversal-safe lookups — only the path resolution changes.

Verified locally against `fastapi==0.115.14` / `starlette==0.46.2`:

| Request | before | after |
|---|---|---|
| `GET /static/lightcurve.css` | 404 | 200 |
| subdir asset | 404 | 200 |
| conditional re-request | – | 304 |
| `GET /static/../api.py` (traversal) | – | 404 (safe) |
| `GET /openapi.json` | 200 | 200 (unchanged) |

## Versioning
Bumped to **0.2.2**. `0.2.1` is already a deployed (broken) image tag, so a fresh tag avoids a mutable-tag overwrite and keeps the deployed image honest with `main`.

## Deploy (after merge)
1. On `main`, build + push: `multisurvey-api:0.2.2`.
2. Update SSM `image.tag` → `0.2.2` (and/or `kubectl set image` + `rollout restart` on `multisurvey-api-lightcurve` as a hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)