### PR TITLE
fix(lightcurve): set Cache-Control: no-cache on static assets

### DIFF
--- a/multisurveys-apis/pyproject.toml
+++ b/multisurveys-apis/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "multisurveys-apis"
-version = "0.2.6"
+version = "0.2.7"
 description = ""
 authors = ["Demurest <eric.apolonio@hotmail.com>"]
 readme = "README.md"

--- a/multisurveys-apis/src/lightcurve_api/api.py
+++ b/multisurveys-apis/src/lightcurve_api/api.py
@@ -53,7 +53,7 @@ TAGS_METADATA = [
 app = FastAPI(
     root_path="/lightcurve_api",
     title="ALeRCE Lightcurve API",
-    version="0.2.6",
+    version="0.2.7",
     description=API_DESCRIPTION,
     openapi_tags=TAGS_METADATA,
     contact={"name": "ALeRCE", "url": "https://alerce.science"},
@@ -86,4 +86,11 @@ _static = StaticFiles(directory="src/static")
 
 @app.get("/static/{path:path}", name="static", include_in_schema=False)
 async def static_files(path: str, request: Request):
-    return await _static.get_response(path, request.scope)
+    response = await _static.get_response(path, request.scope)
+    # Without a Cache-Control header browsers fall back to *heuristic* caching and may
+    # keep serving a stale asset (e.g. an old lightcurve-app.js) without checking the
+    # server, so a deploy silently fails to take effect until a hard refresh. "no-cache"
+    # still lets the browser store the file but forces revalidation against the ETag on
+    # every request: a cheap 304 when unchanged, fresh bytes immediately after a deploy.
+    response.headers["Cache-Control"] = "no-cache"
+    return response


### PR DESCRIPTION
## Problem

After deploying a new lightcurve build, switching objects in the side panel could leave the new object never loading — but only in browsers that had the page cached from a previous version. A fresh/incognito session always worked (verified by driving the live staging page headlessly: 6 real side-panel clicks, every switch loaded correctly).

**Root cause:** the static route served assets with **no `Cache-Control` header** (only `ETag`/`Last-Modified`):

```
last-modified: ...
etag: "..."
   (no cache-control)
```

With no `Cache-Control`, browsers apply *heuristic* caching and can keep serving a stale `lightcurve-app.js` without revalidating. After a deploy the cached JS no longer matches the freshly rendered layout HTML, which surfaces as "the new object never loads." Across several quick successive deploys this is easy to hit.

## Fix

Set `Cache-Control: no-cache` on the static-serving route. The browser may still store assets (so large files like `echarts.min.js` aren't re-downloaded needlessly) but must revalidate against the existing `ETag` on every request — a cheap `304 Not Modified` when unchanged, and fresh bytes immediately after a deploy. No more silent stale-cache after deploys.

Version bump `0.2.6` → `0.2.7`.

## Verification

- Confirmed the deployed `0.2.6` already works in a fresh session via headless CDP against live staging (object switches load every time, no JS errors).
- Confirmed the deployed static response carried no `Cache-Control` header.
- The user confirmed a hard refresh resolved the issue — consistent with stale-cache being the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)