### PR TITLE
fix(lightcurve): QA tweaks to the config panel widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# web-services
+
+Monorepo of ALeRCE web service APIs.
+
+## What's active vs. deprecated
+
+- **[`multisurveys-apis/`](multisurveys-apis/) is the current codebase** — one image/chart
+  serving 8 APIs (lightcurve, object, magstat, crossmatch, probability, aladin, stamp,
+  classifier). New work goes here. See [`multisurveys-apis/CLAUDE.md`](multisurveys-apis/CLAUDE.md).
+- The standalone per-service dirs (`lightcurve/`, `astroobject/`, `xmatch-service/`,
+  `periodapi/`, `tns_api/`, `alerts-api/`, `multisurvey-stamps/`, …) are the **older APIs
+  being deprecated** in favor of their multisurvey versions. Don't extend them unless asked.
+
+## Shared infra
+
+- `charts/` — Helm charts. The active one is `charts/multisurvey_api/`.
+- `ci_new/` — current build/deploy tooling. `ci/` is the old path.
+
+## Conventions (from CI)
+
+Python 3.11, Poetry, [`ruff`](https://docs.astral.sh/ruff/). For `multisurveys-apis/`:
+
+- **Format & lint** (run from `multisurveys-apis/`, ruff line-length 120):
+  ```sh
+  ruff format --check --diff .   # CI: lint.yaml
+  ruff check .
+  ```
+  CI lint only triggers on `multisurveys-apis/**` changes and is currently
+  `continue-on-error` (won't block merge) — but match it anyway before pushing.
+- **Tests** (run from the package dir, e.g. `multisurveys-apis/`):
+  ```sh
+  poetry run pytest -x tests --cov src
+  ```
+  CI (`tests.yaml`) runs pytest per-package, only when that package's files change.
+
+## Workflow
+
+- **Never commit directly to `main`.** Branch and open a PR (PRs target `main` or `staging`).

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/band_toggles.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/band_toggles.html.jinja
@@ -17,24 +17,24 @@
 </label>
 {% endmacro %}
 
-<div class="tw-flex tw-flex-col tw-gap-y-2">
+<div class="tw-flex tw-flex-col tw-gap-2">
 
   <!-- ZTF bands -->
   <div class="tw-flex tw-items-center tw-gap-x-3">
     {{ band_row("ZTF", "Toggle individual ZTF bands in the light curve.") }}
-    <div class="tw-flex tw-gap-x-4">
+    <div class="tw-grid tw-grid-cols-3 tw-gap-2">
       {{ cb("bands.ztf[]", "g", 'g' in config.bands.ztf) }}
       {{ cb("bands.ztf[]", "r", 'r' in config.bands.ztf) }}
       {{ cb("bands.ztf[]", "i", 'i' in config.bands.ztf) }}
     </div>
   </div>
 
-  <!-- LSST bands (6 bands, wrap into 2 rows naturally) -->
+  <!-- LSST bands (6 bands in a fixed 3-column grid: u g r / i z y) -->
   <div class="tw-flex tw-items-start tw-gap-x-3">
     <div class="tw-mt-0.5">
       {{ band_row("LSST", "Toggle individual LSST bands in the light curve.") }}
     </div>
-    <div class="tw-flex tw-flex-wrap tw-gap-x-4 tw-gap-y-1">
+    <div class="tw-grid tw-grid-cols-3 tw-gap-2">
       {% for b in ['u','g','r','i','z','y'] %}
       <label class="tw-flex tw-items-center tw-gap-1 tw-text-sm tw-cursor-pointer">
         <input type="checkbox" name="bands.lsst[]" value="{{ b }}" {% if b in config.bands.lsst %}checked{% endif %} class="tw-cursor-pointer">
@@ -47,7 +47,7 @@
   <!-- ZTF DR bands (shown only when external sources enabled) -->
   <div class="tw-flex tw-items-center tw-gap-x-3 ztf-dr-bands-row {% if not config.external_sources.enabled %}tw-hidden{% endif %}">
     {{ band_row("ZTF DR", "Toggle individual ZTF Data Release bands in the light curve.") }}
-    <div class="tw-flex tw-gap-x-4">
+    <div class="tw-grid tw-grid-cols-3 tw-gap-2">
       {{ cb("bands.ztf_dr[]", "g", 'g' in config.bands.ztf_dr) }}
       {{ cb("bands.ztf_dr[]", "r", 'r' in config.bands.ztf_dr) }}
       {{ cb("bands.ztf_dr[]", "i", 'i' in config.bands.ztf_dr) }}

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/config_panel.html.jinja
@@ -17,30 +17,33 @@
   <div class="tw-flex tw-flex-col tw-items-start tw-gap-y-3">
 
     <!-- Magnitude / Flux -->
-    {{ toggle.toggle("flux", "Mag", "Flux", config.flux, "Toggle between magnitude and flux.", left_w="3rem") }}
+    {{ toggle.toggle("flux", "Mag", "Flux", config.flux, "Toggle between magnitude and flux.", left_w="3rem", neutral=True) }}
 
     <!-- Difference / Total -->
-    {{ toggle.toggle("total", "Diff", "Total", config.total, "Toggle between difference and total (science) magnitude.", left_w="3rem") }}
+    {{ toggle.toggle("total", "Diff", "Total", config.total, "Toggle between difference and total (science) magnitude.", left_w="3rem", neutral=True) }}
 
-    <!-- External sources -->
-    <div class="tw-flex tw-items-center tw-gap-x-2">
-      {{ toggle.toggle("external_sources.enabled", "Ext", "On", config.external_sources.enabled, "Show light curves from available external sets: ZTF Data Release 24.", left_w="3rem") }}
-      <button
-        type="button"
-        class="tw-ml-2 tw-h-6 tw-w-6 tw-flex tw-items-center tw-justify-center tw-border tw-border-gray-300 dark:tw-border-gray-600 tw-rounded hover:tw-bg-gray-50 dark:hover:tw-bg-gray-700 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-blue-500 focus:tw-ring-offset-2 dark:focus:tw-ring-offset-gray-800 tw-shrink-0"
-        aria-label="Filter external sources"
-        hx-get="{{ API_URL }}/htmx/external_sources"
-        hx-target="#dr-picker-container"
-        hx-swap="innerHTML"
-        hx-on::after-request="document.getElementById('dr-picker-container').classList.remove('tw-hidden')"
-        hx-vals='{"oid": "{{ config.oid }}", "survey_id": "{{ config.survey_id }}", "meanra": {{ config.meanra }}, "meandec": {{ config.meandec }}}'
-      >
-        <svg class="tw-w-4 tw-h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z"></path>
-        </svg>
-      </button>
-    </div>
+  </div>
 
+  <div class="tw-w-full tw-h-px tw-bg-gray-200 dark:tw-bg-gray-600 tw-my-3"></div>
+
+  <!-- External sources -->
+  <div class="tw-flex tw-items-center tw-gap-x-2">
+    <span class="tw-font-semibold tw-mr-3 tw-text-gray-900 dark:tw-text-gray-100">External</span>
+    {{ toggle.toggle("external_sources.enabled", "Off", "On", config.external_sources.enabled, "Show light curves from available external sets: ZTF Data Release 24.") }}
+    <button
+      type="button"
+      class="tw-ml-2 tw-h-6 tw-w-6 tw-flex tw-items-center tw-justify-center tw-border tw-border-gray-300 dark:tw-border-gray-600 tw-rounded hover:tw-bg-gray-50 dark:hover:tw-bg-gray-700 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-blue-500 focus:tw-ring-offset-2 dark:focus:tw-ring-offset-gray-800 tw-shrink-0"
+      aria-label="Filter external sources"
+      hx-get="{{ API_URL }}/htmx/external_sources"
+      hx-target="#dr-picker-container"
+      hx-swap="innerHTML"
+      hx-on::after-request="document.getElementById('dr-picker-container').classList.remove('tw-hidden')"
+      hx-vals='{"oid": "{{ config.oid }}", "survey_id": "{{ config.survey_id }}", "meanra": {{ config.meanra }}, "meandec": {{ config.meandec }}}'
+    >
+      <svg class="tw-w-4 tw-h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.707A1 1 0 013 7V4z"></path>
+      </svg>
+    </button>
   </div>
 
   <div class="tw-w-full tw-h-px tw-bg-gray-200 dark:tw-bg-gray-600 tw-my-3"></div>
@@ -52,7 +55,10 @@
   <div class="tw-w-full tw-h-px tw-bg-gray-200 dark:tw-bg-gray-600 tw-my-3"></div>
 
   <div class="tw-flex tw-flex-col tw-items-start tw-gap-y-2">
-    {{ toggle.toggle("offset_bands", "Offset", "On", config.offset_bands, "Apply a magnitude or flux offset between bands.") }}
+    <div>
+      <span class="tw-font-semibold tw-mr-3 tw-text-gray-900 dark:tw-text-gray-100">Offset</span>
+      {{ toggle.toggle("offset_bands", "Off", "On", config.offset_bands, "Apply a magnitude or flux offset between bands.") }}
+    </div>
     <div class="tw-flex tw-items-center tw-gap-x-2 tw-mt-2 tw-ml-1">
       <input name="offset_num" type="range" min="1" max="10" value="{{ config.offset_num }}"
              class="tw-w-24 tw-h-2 tw-bg-gray-200 tw-rounded-lg tw-appearance-none tw-cursor-pointer dark:tw-bg-gray-700">

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/fold_controls.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/fold_controls.html.jinja
@@ -34,7 +34,6 @@ input.addEventListener('change', function(e) {
 x2.addEventListener('click', function(e) {
   input.value = input.value * 2;
   if (input.value > 500) input.value = 500
-  if (input.value < 0.05) input.value = 0.05
 
   input.dispatchEvent(new Event('change', { bubbles: true }));
 })
@@ -42,7 +41,6 @@ x2.addEventListener('click', function(e) {
 div2.addEventListener('click', function(e) {
   input.value = input.value / 2;
   if (input.value > 500) input.value = 500
-  if (input.value < 0.05) input.value = 0.05
   input.dispatchEvent(new Event('change', { bubbles: true }));
 })
 

--- a/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/toggle.html.jinja
+++ b/multisurveys-apis/src/lightcurve_api/routes/htmx/templates/toggle.html.jinja
@@ -1,4 +1,4 @@
-{% macro toggle(name, left, right, checked=False, tooltip="", disable=False, left_w="") -%}
+{% macro toggle(name, left, right, checked=False, tooltip="", disable=False, left_w="", neutral=False) -%}
 <label class="tw-inline-flex tw-items-center tw-cursor-pointer">
   {% if tooltip %}
   <div class="tw-relative tw-group tw-mr-2">
@@ -14,7 +14,7 @@
   {% endif %}
   <span class="tw-font-semibold tw-mr-3 tw-text-gray-900 dark:tw-text-gray-100{% if left_w %} tw-inline-block tw-text-right{% endif %}"{% if left_w %} style="width:{{ left_w }}"{% endif %}>{{ left }}</span>
   <input type="checkbox" name="{{ name }}" class="tw-sr-only tw-peer" {% if checked %}checked{% endif %} {% if disable %}disabled{% endif %}>
-  <div class="tw-relative tw-w-11 tw-h-6 tw-bg-gray-200 peer-focus:tw-outline-none tw-rounded-full tw-peer dark:tw-bg-gray-700 peer-checked:after:tw-translate-x-full rtl:peer-checked:after:-tw-translate-x-full peer-checked:after:tw-border-white after:tw-content-[''] after:tw-absolute after:tw-top-[2px] after:tw-start-[2px] after:tw-bg-white after:tw-border-gray-300 after:tw-border after:tw-rounded-full after:tw-h-5 after:tw-w-5 after:tw-transition-all dark:tw-border-gray-600 peer-checked:tw-bg-gray-600 dark:peer-checked:tw-bg-gray-600"></div>
+  <div class="tw-relative tw-w-11 tw-h-6 tw-bg-gray-200 peer-focus:tw-outline-none tw-rounded-full tw-peer dark:tw-bg-gray-700 peer-checked:after:tw-translate-x-full rtl:peer-checked:after:-tw-translate-x-full after:tw-content-[''] after:tw-absolute after:tw-top-[2px] after:tw-start-[2px] after:tw-bg-white after:tw-border-gray-300 after:tw-border after:tw-rounded-full after:tw-h-5 after:tw-w-5 after:tw-transition-all dark:tw-border-gray-600{% if not neutral %} peer-checked:after:tw-border-white peer-checked:tw-bg-gray-600 dark:peer-checked:tw-bg-gray-600{% endif %}"></div>
   <span class="tw-font-semibold tw-ml-3 tw-text-gray-900 dark:tw-text-gray-100">{{ right }}</span>
 </label>
 {%- endmacro %}


### PR DESCRIPTION
Addresses QA feedback (Alejandra) on the multisurvey lightcurve widget config panel.

## Changes

**LSST bands** — laid out in a 3-column grid (`u g r` / `i z y`); ZTF and ZTF-DR rows now use the same grid so all band checkboxes align in columns. Switched the band container to `tw-gap-2` (the previous `tw-gap-y-2`/`tw-gap-x-*` classes aren't present in the served `lightcurve.css`) so vertical spacing between rows is uniform.

**Period** — the period text box now accepts values below `0.05`; removed the `< 0.05` clamps in the X2/÷2 handlers. The slider keeps its `0.05` minimum.

**External toggle** — moved into its own group, bounded by horizontal dividers, with an "External" heading following the Fold/Periodogram structure. Offset got the same heading + Off/On structure.

**Mag/Flux & Diff/Total toggles** — added a `neutral` flag to the toggle macro so these A↔B selectors keep a constant track color (the knob still slides), instead of darkening on the right as if "on". On/off toggles (External, Fold, Periodogram, Offset) are unchanged.

Also adds a repo-level `CLAUDE.md` documenting the monorepo layout and conventions (separate commit).

## Notes
- Template-only changes; they rely on classes already present in the served `lightcurve.css`, so no Tailwind rebuild is required.
- Verified against `oid=170032883300827210&survey_id=lsst` running locally (headless screenshots).
- Per the deploy runbook, the multisurvey image build + deploy is manual — staging won't reflect this until rebuilt and deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)