### PR TITLE
Refactor query get all objects

### DIFF
--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -82,7 +82,8 @@ def query_get_objects(session_ms, search_params, parsed_params):
             .join(
                 object_alias,
                 and_(object_alias.oid == probability_alias.oid),
-            ).join(
+            )
+            .join(
                 dynamic_object_alias,
                 and_(dynamic_object_alias.oid == probability_alias.oid),
             )
@@ -101,35 +102,26 @@ def query_get_objects(session_ms, search_params, parsed_params):
             items = sort_by_oid_list_and_select_page(search_params, items)
 
         return Pagination(pagination_args.page, pagination_args.page_size, items)
-    
+
 
 def subquery_probability(filters):
-
-    stmt = (
-        select(Probability)
-        .where(*filters)
-        .subquery()
-    )
+    stmt = select(Probability).where(*filters).subquery()
 
     probability_alias = aliased(Probability, stmt)
 
     return probability_alias
 
+
 def subquery_object(filters, parsed_params):
     consearch = parsed_params["consearch_statement"]
     consearch_args = parsed_params["consearch_args"]
 
-    stmt = (
-        select(Object)
-        .where(*filters)
-        .where(consearch)
-        .params(**consearch_args)
-        .subquery()
-    )
+    stmt = select(Object).where(*filters).where(consearch).params(**consearch_args).subquery()
 
     object_alias = aliased(Object, stmt)
 
     return object_alias
+
 
 def dinamic_object_model(survey):
     model_id = ObjectsModels(survey).get_model_by_survey()

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -78,7 +78,7 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
     with session_ms() as session:
         stmt = (
-            select(probability_alias, object_alias)
+            select(probability_alias, object_alias, dynamic_object_alias)
             .join(
                 object_alias,
                 and_(object_alias.oid == probability_alias.oid),
@@ -105,7 +105,7 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
 
 def subquery_probability(filters):
-    stmt = select(Probability).where(*filters).subquery()
+    stmt = select(Probability).where(*filters).cte("tprobability")
 
     probability_alias = aliased(Probability, stmt)
 
@@ -116,7 +116,7 @@ def subquery_object(filters, parsed_params):
     consearch = parsed_params["consearch_statement"]
     consearch_args = parsed_params["consearch_args"]
 
-    stmt = select(Object).where(*filters).where(consearch).params(**consearch_args).subquery()
+    stmt = select(Object).where(*filters).where(consearch).params(**consearch_args).cte("tobject")
 
     object_alias = aliased(Object, stmt)
 

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -126,49 +126,12 @@ def query_get_objects(session_ms, search_params, parsed_params):
         if len(order_statement) > 0:
             stmt = add_limits_statements(stmt, pagination_args)
 
-        # print(stmt.compile(session.bind, compile_kwargs={"literal_binds": True}))
-
         items = session.execute(stmt).all()
 
         # if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
         #     items = sort_by_oid_list_and_select_page(search_params, items)
 
         return Pagination(pagination_args.page, pagination_args.page_size, items)
-
-
-
-# def query_get_objects(session_ms, search_params, parsed_params):
-#     filter_args = search_params.filter_args
-#     filters_statements = parsed_params["filters_sqlalchemy_statement"]
-#     pagination_args = check_pagination_args(search_params.pagination_args)
-
-#     with session_ms() as session:
-#         object_alias, dinamic_model_alias = build_subquery_object(
-#             filter_args.survey, filters_statements["objects"], parsed_params
-#         )
-
-#         stmt = (
-#             select(Probability, object_alias, dinamic_model_alias)
-#             .join(
-#                 dinamic_model_alias,
-#                 and_(dinamic_model_alias.oid == Probability.oid),
-#             )
-#             .where(*filters_statements["probability"])
-#         )
-
-#         order_statement = create_order_statement(stmt, search_params.order_args)
-
-#         stmt = stmt.order_by(*order_statement)
-
-#         if len(order_statement) > 0:
-#             stmt = add_limits_statements(stmt, pagination_args)
-
-#         items = session.execute(stmt).all()
-
-#         if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
-#             items = sort_by_oid_list_and_select_page(search_params, items)
-
-#         return Pagination(pagination_args.page, pagination_args.page_size, items)
 
 
 def sort_by_oid_list_and_select_page(search_params, items):
@@ -186,26 +149,6 @@ def sort_by_oid_list_and_select_page(search_params, items):
     df_items = list(df_items.itertuples(index=False, name=None))
 
     return df_items
-
-
-def build_subquery_object(survey, filters, parsed_params):
-    model_id = ObjectsModels(survey).get_model_by_survey()
-    consearch = parsed_params["consearch_statement"]
-    consearch_args = parsed_params["consearch_args"]
-
-    stmt = (
-        select(Object, model_id)
-        .join(model_id, and_(model_id.oid == Object.oid))
-        .where(*filters)
-        .where(consearch)
-        .params(**consearch_args)
-        .subquery()
-    )
-
-    object_alias = aliased(Object, stmt)
-    dinamic_model_alias = aliased(model_id, stmt)
-
-    return object_alias, dinamic_model_alias
 
 
 def check_pagination_args(pagination_args):

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -66,37 +66,6 @@ def build_statement_object(model_id, oid):
 
     return stmt
 
-def subquery_probability(filters):
-
-    stmt = (
-        select(Probability)
-        .where(*filters)
-        .subquery()
-    )
-
-    probability_alias = aliased(Probability, stmt)
-
-    return probability_alias
-
-def subquery_object(filters, parsed_params):
-    consearch = parsed_params["consearch_statement"]
-    consearch_args = parsed_params["consearch_args"]
-
-    stmt = (
-        select(Object)
-        .where(*filters)
-        .where(consearch)
-        .params(**consearch_args)
-        .subquery()
-    )
-
-    object_alias = aliased(Object, stmt)
-
-    return object_alias
-
-def dinamic_object_model(survey):
-    model_id = ObjectsModels(survey).get_model_by_survey()
-    return model_id
 
 def query_get_objects(session_ms, search_params, parsed_params):
     filters_objects = parsed_params["filters_sqlalchemy_statement"]["objects"]
@@ -132,6 +101,39 @@ def query_get_objects(session_ms, search_params, parsed_params):
         #     items = sort_by_oid_list_and_select_page(search_params, items)
 
         return Pagination(pagination_args.page, pagination_args.page_size, items)
+    
+
+def subquery_probability(filters):
+
+    stmt = (
+        select(Probability)
+        .where(*filters)
+        .subquery()
+    )
+
+    probability_alias = aliased(Probability, stmt)
+
+    return probability_alias
+
+def subquery_object(filters, parsed_params):
+    consearch = parsed_params["consearch_statement"]
+    consearch_args = parsed_params["consearch_args"]
+
+    stmt = (
+        select(Object)
+        .where(*filters)
+        .where(consearch)
+        .params(**consearch_args)
+        .subquery()
+    )
+
+    object_alias = aliased(Object, stmt)
+
+    return object_alias
+
+def dinamic_object_model(survey):
+    model_id = ObjectsModels(survey).get_model_by_survey()
+    return model_id
 
 
 def sort_by_oid_list_and_select_page(search_params, items):

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -97,8 +97,8 @@ def query_get_objects(session_ms, search_params, parsed_params):
 
         items = session.execute(stmt).all()
 
-        # if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
-        #     items = sort_by_oid_list_and_select_page(search_params, items)
+        if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
+            items = sort_by_oid_list_and_select_page(search_params, items)
 
         return Pagination(pagination_args.page, pagination_args.page_size, items)
     

--- a/multisurveys-apis/src/core/repository/queries/objects.py
+++ b/multisurveys-apis/src/core/repository/queries/objects.py
@@ -66,24 +66,57 @@ def build_statement_object(model_id, oid):
 
     return stmt
 
+def subquery_probability(filters):
+
+    stmt = (
+        select(Probability)
+        .where(*filters)
+        .subquery()
+    )
+
+    probability_alias = aliased(Probability, stmt)
+
+    return probability_alias
+
+def subquery_object(filters, parsed_params):
+    consearch = parsed_params["consearch_statement"]
+    consearch_args = parsed_params["consearch_args"]
+
+    stmt = (
+        select(Object)
+        .where(*filters)
+        .where(consearch)
+        .params(**consearch_args)
+        .subquery()
+    )
+
+    object_alias = aliased(Object, stmt)
+
+    return object_alias
+
+def dinamic_object_model(survey):
+    model_id = ObjectsModels(survey).get_model_by_survey()
+    return model_id
 
 def query_get_objects(session_ms, search_params, parsed_params):
-    filter_args = search_params.filter_args
-    filters_statements = parsed_params["filters_sqlalchemy_statement"]
+    filters_objects = parsed_params["filters_sqlalchemy_statement"]["objects"]
+    filters_probability = parsed_params["filters_sqlalchemy_statement"]["probability"]
     pagination_args = check_pagination_args(search_params.pagination_args)
 
-    with session_ms() as session:
-        object_alias, dinamic_model_alias = build_subquery_object(
-            filter_args.survey, filters_statements["objects"], parsed_params
-        )
+    probability_alias = subquery_probability(filters_probability)
+    object_alias = subquery_object(filters_objects, parsed_params)
+    dynamic_object_alias = dinamic_object_model(search_params.filter_args.survey)
 
+    with session_ms() as session:
         stmt = (
-            select(Probability, object_alias, dinamic_model_alias)
+            select(probability_alias, object_alias)
             .join(
-                dinamic_model_alias,
-                and_(dinamic_model_alias.oid == Probability.oid),
+                object_alias,
+                and_(object_alias.oid == probability_alias.oid),
+            ).join(
+                dynamic_object_alias,
+                and_(dynamic_object_alias.oid == probability_alias.oid),
             )
-            .where(*filters_statements["probability"])
         )
 
         order_statement = create_order_statement(stmt, search_params.order_args)
@@ -93,12 +126,49 @@ def query_get_objects(session_ms, search_params, parsed_params):
         if len(order_statement) > 0:
             stmt = add_limits_statements(stmt, pagination_args)
 
+        # print(stmt.compile(session.bind, compile_kwargs={"literal_binds": True}))
+
         items = session.execute(stmt).all()
 
-        if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
-            items = sort_by_oid_list_and_select_page(search_params, items)
+        # if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
+        #     items = sort_by_oid_list_and_select_page(search_params, items)
 
         return Pagination(pagination_args.page, pagination_args.page_size, items)
+
+
+
+# def query_get_objects(session_ms, search_params, parsed_params):
+#     filter_args = search_params.filter_args
+#     filters_statements = parsed_params["filters_sqlalchemy_statement"]
+#     pagination_args = check_pagination_args(search_params.pagination_args)
+
+#     with session_ms() as session:
+#         object_alias, dinamic_model_alias = build_subquery_object(
+#             filter_args.survey, filters_statements["objects"], parsed_params
+#         )
+
+#         stmt = (
+#             select(Probability, object_alias, dinamic_model_alias)
+#             .join(
+#                 dinamic_model_alias,
+#                 and_(dinamic_model_alias.oid == Probability.oid),
+#             )
+#             .where(*filters_statements["probability"])
+#         )
+
+#         order_statement = create_order_statement(stmt, search_params.order_args)
+
+#         stmt = stmt.order_by(*order_statement)
+
+#         if len(order_statement) > 0:
+#             stmt = add_limits_statements(stmt, pagination_args)
+
+#         items = session.execute(stmt).all()
+
+#         if search_params.filter_args.oids is not None and search_params.order_args.order_by is None and len(items) > 0:
+#             items = sort_by_oid_list_and_select_page(search_params, items)
+
+#         return Pagination(pagination_args.page, pagination_args.page_size, items)
 
 
 def sort_by_oid_list_and_select_page(search_params, items):

--- a/multisurveys-apis/src/object_api/routes/htmx.py
+++ b/multisurveys-apis/src/object_api/routes/htmx.py
@@ -18,11 +18,7 @@ from ..services.tns_service import get_tns
 from ..services.idmapper.idmapper import encode_ids
 from ..services.jinja_tools import truncate_float
 from core.exceptions import ObjectNotFound
-from object_api.services.object_services import (
-    get_object_by_id,
-    get_objects_list,
-    get_tidy_classifiers
-)
+from object_api.services.object_services import get_object_by_id, get_objects_list, get_tidy_classifiers
 from ..services.parsers import (
     _parse_oids_string_to_array,
     save_date_in_array,
@@ -126,7 +122,6 @@ async def select_classes_classifier(request: Request, classifier_classes: list[s
     except Exception:
         traceback.print_exc()
         raise HTTPException(status_code=500, detail="An error occurred")
-
 
 
 @router.get("/htmx/list_objects", response_class=HTMLResponse)

--- a/multisurveys-apis/src/object_api/routes/htmx.py
+++ b/multisurveys-apis/src/object_api/routes/htmx.py
@@ -1,13 +1,10 @@
 import os
 import traceback
-from typing import Annotated
 from fastapi import APIRouter, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from ..services.object_services import get_tidy_classifiers
 from ..models.filters import Consearch, Filters, SearchParams
 from ..models.pagination import Order, PaginationArgs
-from ..services.object_services import get_objects_list
 from ..services.validations import (
     ndets_validation,
     order_mode_validation,
@@ -23,8 +20,13 @@ from ..services.jinja_tools import truncate_float
 from core.exceptions import ObjectNotFound
 from object_api.services.object_services import (
     get_object_by_id,
+    get_objects_list,
+    get_tidy_classifiers
 )
-from ..services.parsers import _parse_oids_string_to_array
+from ..services.parsers import (
+    _parse_oids_string_to_array,
+    save_date_in_array,
+)
 
 router = APIRouter()
 
@@ -126,6 +128,7 @@ async def select_classes_classifier(request: Request, classifier_classes: list[s
         raise HTTPException(status_code=500, detail="An error occurred")
 
 
+
 @router.get("/htmx/list_objects", response_class=HTMLResponse)
 def objects_table(
     request: Request,
@@ -137,15 +140,15 @@ def objects_table(
     n_det_min: int | None = None,
     n_det_max: int | None = None,
     probability: float | None = None,
-    firstmjd: Annotated[list[float] | None, Query()] = None,
-    lastmjd: Annotated[list[float] | None, Query()] = None,
+    firstmjd: float | None = None,
+    lastmjd: float | None = None,
     dec: float | None = None,
     ra: float | None = None,
     radius: float | None = None,
     page: int | None = 1,
     page_size: int | None = 20,
     count: bool | None = False,
-    order_by: str | None = None,  # Query(default="probability"),
+    order_by: str | None = None,
     order_mode: str | None = Query(default="DESC"),
 ):
     try:
@@ -160,7 +163,7 @@ def objects_table(
             oids_format_validation(oid, survey)
             oid_lenght_validation(oid)
             probability_validation(probability, classifier, class_name)
-            date_validation(firstmjd)
+            date_validation(firstmjd, lastmjd)
 
             if oid is None and order_by is None:
                 order_by = "probability"
@@ -170,6 +173,9 @@ def objects_table(
 
             if oid is not None:
                 oid = encode_ids(survey, oid)
+
+            firstmjd = save_date_in_array(firstmjd)
+            lastmjd = save_date_in_array(lastmjd)
 
             filters = Filters(
                 oids=oid,
@@ -244,15 +250,15 @@ def sidebar(
     n_det_min: int | None = None,
     n_det_max: int | None = None,
     probability: float | None = None,
-    firstmjd: Annotated[list[float] | None, Query()] = None,
-    lastmjd: Annotated[list[float] | None, Query()] = None,
+    firstmjd: float | None = None,
+    lastmjd: float | None = None,
     dec: float | None = None,
     ra: float | None = None,
     radius: float | None = None,
     page: int | None = 1,
     page_size: int | None = 20,
     count: bool | None = False,
-    order_by: str | None = None,  # Query(default="probability"),
+    order_by: str | None = None,
     order_mode: str | None = Query(default="DESC"),
 ):
     try:
@@ -268,7 +274,7 @@ def sidebar(
             oids_format_validation(oid, survey)
             oid_lenght_validation(oid)
             probability_validation(probability, classifier, class_name)
-            date_validation(firstmjd)
+            date_validation(firstmjd, lastmjd)
 
             if oid is None and order_by is None:
                 order_by = "probability"
@@ -278,6 +284,9 @@ def sidebar(
 
             if oid is not None:
                 oid = encode_ids(survey, oid)
+
+            firstmjd = save_date_in_array(firstmjd)
+            lastmjd = save_date_in_array(lastmjd)
 
             filters = Filters(
                 oids=oid,

--- a/multisurveys-apis/src/object_api/services/parsers.py
+++ b/multisurveys-apis/src/object_api/services/parsers.py
@@ -135,3 +135,10 @@ def _parse_oids_string_to_array(oids_list):
         oids_list = [oid for oid in oids_list if oid != ""]
 
     return oids_list
+
+
+def save_date_in_array(date) -> list[float]:
+    if date is not None:
+        return [date]
+    
+    return None

--- a/multisurveys-apis/src/object_api/services/parsers.py
+++ b/multisurveys-apis/src/object_api/services/parsers.py
@@ -140,5 +140,5 @@ def _parse_oids_string_to_array(oids_list):
 def save_date_in_array(date) -> list[float]:
     if date is not None:
         return [date]
-    
+
     return None

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -100,7 +100,9 @@ def object_filters(args):
         filters_dict.append(firstmjd)
 
     if args["lastmjd"] is not None:
-        lastmjd = Object.lastmjd <= args["lastmjd"][0]
+        lastmjd = Object.lastmjd >= args["lastmjd"][0]
+        if len(args["lastmjd"]) > 1:
+            lastmjd = lastmjd & (Object.lastmjd <= args["lastmjd"][1])
         filters_dict.append(lastmjd)
 
     if args["oids"] is not None:

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -120,8 +120,6 @@ def object_filters(args):
             survey = Object.sid == 1
             filters_dict.append(survey)
 
-    
-
     return filters_dict
 
 

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -100,9 +100,7 @@ def object_filters(args):
         filters_dict.append(firstmjd)
 
     if args["lastmjd"] is not None:
-        lastmjd = Object.lastmjd >= args["lastmjd"][0]
-        if len(args["lastmjd"]) > 1:
-            lastmjd = lastmjd & (Object.lastmjd <= args["lastmjd"][1])
+        lastmjd = Object.lastmjd <= args["lastmjd"][0]
         filters_dict.append(lastmjd)
 
     if args["oids"] is not None:

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -113,6 +113,16 @@ def object_filters(args):
             oids = Object.oid.in_(args["oids"])
         filters_dict.append(oids)
 
+    if args["survey"] is not None:
+        if args["survey"] == "ztf":
+            survey = Object.sid == 0
+            filters_dict.append(survey)
+        if args["survey"] == "lsst":
+            survey = Object.sid == 1
+            filters_dict.append(survey)
+
+    
+
     return filters_dict
 
 

--- a/multisurveys-apis/src/object_api/services/statements_sql.py
+++ b/multisurveys-apis/src/object_api/services/statements_sql.py
@@ -105,7 +105,6 @@ def object_filters(args):
 
     if args["oids"] is not None:
         if len(args["oids"]) == 1:
-            # filtered_oid = args["oids"][0].replace("*", "%")
             oids = Object.oid == args["oids"][0]
         else:
             oids = Object.oid.in_(args["oids"])

--- a/multisurveys-apis/src/object_api/services/validations.py
+++ b/multisurveys-apis/src/object_api/services/validations.py
@@ -101,17 +101,17 @@ def probability_validation(probability, classifier, class_name):
                 )
 
 
-def date_validation(firstmjd):
+def date_validation(firstmjd, lastmjd):
     if firstmjd is not None:
-        if len(firstmjd) > 2:
+        if not isinstance(firstmjd, float):
             raise HTTPException(
                 status_code=422,
-                detail={"discovery_date_filters_container": "To filter by date, there must be a maximum of two dates."},
+                detail={"discovery_date_filters_container": "The date must be a float."},
             )
 
-        if len(firstmjd) == 2:
-            if firstmjd[0] >= firstmjd[1]:
-                raise HTTPException(
-                    status_code=422,
-                    detail={"discovery_date_filters_container": "Min MJD must be lower than max MJD."},
-                )
+    if lastmjd is not None and firstmjd is not None:
+        if firstmjd >= lastmjd:
+            raise HTTPException(
+                status_code=422,
+                detail={"discovery_date_filters_container": "Min MJD must be lower than max MJD."},
+            )

--- a/multisurveys-apis/src/object_api/static/search_form/api_payload_helpers.js
+++ b/multisurveys-apis/src/object_api/static/search_form/api_payload_helpers.js
@@ -3,7 +3,8 @@ import { format_oids, check_radio_consearch } from "../ui_helpers.js";
 
 function send_form_Data() {
   let ndet_arr = get_values_array_fields(["min_detections", "max_detections"])
-  let first_mjd_arr = get_values_array_fields(["min_mjd", "max_mjd"])
+  let first_mjd = document.getElementById("min_mjd").value
+  let last_mjd = document.getElementById("max_mjd").value
   let probability_value = parseFloat(document.getElementById("prob_range").value);
   let class_selected = document.getElementById("class")
   let classifier_selected = document.getElementById("classifier")
@@ -23,7 +24,8 @@ function send_form_Data() {
     probability: probability_value > 0 ? probability_value : null,
     n_det_min: ndet_arr.length > 0 && ndet_arr[0] !== null ? parseInt(ndet_arr[0]) : null,
     n_det_max: ndet_arr.length > 1 && ndet_arr[1] !== null ? parseInt(ndet_arr[1]) : null,
-    firstmjd: first_mjd_arr.length > 0 ? first_mjd_arr : null,
+    firstmjd: first_mjd != '' ? parseFloat(first_mjd) : null,
+    lastmjd: last_mjd != '' ? parseFloat(last_mjd) : null,
     ra: !isNaN(parseFloat(ra_consearch)) ? ra_consearch : null,
     dec: !isNaN(parseFloat(dec_consearch)) ? dec_consearch : null,
     radius: !isNaN(parseFloat(radius_consearch)) ? radius_consearch : null,
@@ -94,14 +96,6 @@ function _check_is_empty(value){
   return false
 }
 
-function _check_max_arr_position(index, response_array){
-  if (index == 1 && response_array.length == 0 ){
-    return true
-  }
-
-  return false
-}
-
 function get_values_array_fields(fields){
   let response_array = []
 
@@ -119,6 +113,14 @@ function get_values_array_fields(fields){
 
   
   return response_array
+}
+
+function _check_max_arr_position(index, response_array){
+  if (index == 1 && response_array.length == 0 ){
+    return true
+  }
+
+  return false
 }
 
 export {

--- a/multisurveys-apis/src/object_api/static/search_form/form_restore_functions.js
+++ b/multisurveys-apis/src/object_api/static/search_form/form_restore_functions.js
@@ -116,17 +116,17 @@ function restore_n_det(urlParams) {
 }
 
 function restore_mjd(urlParams) {
+  let firstmjd = urlParams.getAll('firstmjd')
+  let lastmjd = urlParams.getAll('lastmjd')
 
-  const firstmjds = urlParams.getAll('firstmjd')
-  if (firstmjds.length > 0) {
-    if (firstmjds[0]) {
-      document.getElementById('min_mjd').value = firstmjds[0]
-      document.getElementById('min_mjd').dispatchEvent(new Event('input'))
-    }
-    if (firstmjds[1]) {
-      document.getElementById('max_mjd').value = firstmjds[1]
-      document.getElementById('max_mjd').dispatchEvent(new Event('input'))
-    }
+  if (firstmjd.length > 0) {
+    document.getElementById('min_mjd').value = firstmjd
+    document.getElementById('min_mjd').dispatchEvent(new Event('input'))
+  }
+
+  if (lastmjd.length > 0) {
+    document.getElementById('max_mjd').value = lastmjd
+    document.getElementById('max_mjd').dispatchEvent(new Event('input'))
   }
 
 }


### PR DESCRIPTION
## Summary of the changes



## Observations

<-- Add some notes to keep in mind !-->
This PR is a refactor of the query to get a objects list, this is on the object_api. The refactor includes the structure of the query, first execute each subquery related with the main tables and then execute the joins. The benefits are the speed in time execution of the query.

Also a fix is include related of how firstmjd and lastmjd are read in the htmx.

## If the change is BREAKING, please give more details about the breaking changes

<-- What change breaks what and how !-->

#### Components that need updates and steps to follow

<-- Link repos or other PRs !-->


## About this PR:

- [ ] You added the necessary documentation for the team to understand your work.
- [ ] You linked this PR to the corresponding issue or user story.
- [ ] Your changes fulfill the Definition of Done of the issue or user story.
- [ ] Your changes were tested with manual testing before being submitted.
- [ ] Your changes were tested with automatic unit tests.
- [ ] Your changes were tested with automatic integration tests.


## Screensshots

<-- Add some screenshots if necessary !-->