### PR TITLE
feat(chart): opt-in topologySpreadConstraints for alerts-api

### DIFF
--- a/charts/alerts-api/templates/deployment.yaml
+++ b/charts/alerts-api/templates/deployment.yaml
@@ -148,6 +148,18 @@ spec:
             items:
               - key: "default.conf"
                 path: "default.conf"
+      {{- if .Values.topologySpread.enabled }}
+      {{- /* Selector from the helper, not hand-written: nameOverride is not
+             uniform across releases, so a copied selector matches zero pods
+             and the spreading silently does nothing. */}}
+      topologySpreadConstraints:
+        - maxSkew: {{ .Values.topologySpread.maxSkew }}
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: {{ .Values.topologySpread.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              {{- include "alerts-api.selectorLabels" . | nindent 14 }}
+      {{- end }}
       {{- if or .Values.affinity .Values.podAntiAffinity.enabled }}
       affinity:
         {{- with .Values.affinity }}

--- a/charts/alerts-api/values.yaml
+++ b/charts/alerts-api/values.yaml
@@ -56,6 +56,17 @@ affinity:
 podAntiAffinity:
   enabled: false
 
+# Node spreading, complementing podAntiAffinity. The anti-affinity preference
+# alone proved too weak: at 512Mi requests the scheduler's least-allocated
+# scoring dominated it and stacked 10 of 16 replicas onto one nearly-empty node.
+# whenUnsatisfiable stays ScheduleAnyway on purpose -- DoNotSchedule would let
+# pods go Pending under node pressure and block HPA scale-up, which is the worst
+# time to lose capacity. Inert unless enabled.
+topologySpread:
+  enabled: false
+  maxSkew: 2
+  whenUnsatisfiable: ScheduleAnyway
+
 configmap:
   port: ""
   apiUrl: ""


### PR DESCRIPTION
Adds an inert `topologySpread` block to the `alerts-api` chart. Applied to `ws-alerts-api` on 27/07/2026 (release r19).

## Why

The soft `podAntiAffinity` added in 481f1fdfa was not enough on its own. Raising `ws-alerts-api`'s memory request from `128M` to `512Mi` (containment for the `/metrics` cardinality leak) made the scheduler's least-allocated scoring dominate the anti-affinity preference — which was already at max weight 100 — and it stacked **10 of 16** replicas onto one nearly-empty node (376Mi requested, so hugely attractive).

That was *worse* concentration than the pre-rollout 4/3/3/2/2/2. After the HPA scaled to 8 it settled at 4/2/1/1, still half the capacity on one node — the SPOF this hardening exists to remove.

With this block applied, placement went to **2/2/2/1/1 across five nodes**.

## Notes

- **Inert by default** (`enabled: false`), so no behaviour change for any release that does not opt in.
- The label selector comes from the `selectorLabels` helper rather than values, for the same reason as the anti-affinity block: `nameOverride` is not uniform across releases, so a hand-copied selector matches zero pods and silently spreads nothing.
- `whenUnsatisfiable` defaults to `ScheduleAnyway`, not `DoNotSchedule`. A hard constraint is satisfiable at today's replica counts, but it can leave pods Pending under node pressure and block HPA scale-up exactly when load is highest.

General lesson worth keeping: **a soft anti-affinity preference is not a spreading guarantee, and request changes interact with placement rules** — check placement after any request bump.

Full context: `planning/projects/service-performance/docs/web-services-deployment-audit.md` §9e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)