### PR TITLE
fix(lightcurve): commit the poolclass=NullPool production already runs

### DIFF
--- a/lightcurve/src/database/sql.py
+++ b/lightcurve/src/database/sql.py
@@ -5,6 +5,7 @@ from typing import Generator
 
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,10 @@ db_url = f"postgresql://{user}:{pwd}@{host}:{port}/{db}"
 
 
 def connect() -> Engine:
-    engine: Engine = create_engine(db_url, echo=False)
+    # NullPool: pgbouncer already does transaction pooling in front of
+    # Postgres, so an app-side pool would double-pool. This is not "a new
+    # connection per request per Postgres" -- it means no *second* pool.
+    engine: Engine = create_engine(db_url, echo=False, poolclass=NullPool)
     return engine
 
 


### PR DESCRIPTION
Step 0 of the rec-1 rollout for `ws-lightcurve` (lightcurve latency investigation §8c). **Repo hygiene, not a deploy: this changes nothing that is serving.**

## Why

The five ZTF `ws-*` releases all pin `lightcurve@sha256:00772bb1...` (tag `rc-nullpool`, deployed 26/07/2026), which was hand-built from a working tree carrying `poolclass=NullPool` in `lightcurve/src/database/sql.py`. That line was never merged — `main`'s `connect()` is plain `create_engine(db_url, echo=False)`. A `tar` of the running pod's `/app/src` diffed against `main` shows it is the **only** source difference (the four `static/*.css` diffs are Tailwind regenerated at image build; `src/api/static` is an empty build dir).

`NullPool` is also the correct setting here: pgbouncer already does transaction pooling in front of Postgres, so an app-side pool would double-pool. The comment is reused verbatim from 709fd4ca1 (same fix for `alerts-api`), because the deployment audit records people mistaking `NullPool` for a defect.

## Why now

The next image built from `main` would revert it silently, in a release whose diff does not mention it. The next build is the AUTOCOMMIT engine change (rec 1: **−1308 ms** measured over the five reads of the ZTF htmx path), so without this commit that release would ship two changes — one invisible — and any regression would be un-attributable. Landing it separately keeps the next PR to one behavioural line.

## Blast radius

`connect()` is shared by all five sub-apps in the image (`lightcurve_api`, `object_api`, `magstats_api`, `probability_api`, `crossmatch_api`) → the five `ws-*` Helm releases. All five already run `NullPool` in production, so no release changes behaviour from this merge. No image is built or deployed by merging this (CD for `lightcurve` is bypassed; deploys are manual `helm upgrade`).

## Verification

- `lightcurve_tests` (CI, `tests.yaml`) is the bed for "nothing depended on the pooling class".
- `isort`/`black`/`ruff` line-length 79 respected; import ordering matches the existing block.
- Runtime behaviour is verified by the fact that it is already the deployed code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
