### PR TITLE
perf(lightcurve): AUTOCOMMIT engine, -1308 ms on the htmx lightcurve path

### DIFF
--- a/charts/lightcurve/Chart.yaml
+++ b/charts/lightcurve/Chart.yaml
@@ -1,8 +1,8 @@
-appVersion: 26.5.1rc1
+appVersion: 26.7.2
 description: Lightcurve API for ALeRCE Clients
 name: lightcurve
 type: application
-version: 26.5.185
+version: 26.7.186
 
 
 

--- a/lightcurve/pyproject.toml
+++ b/lightcurve/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lightcurve"
-version = "26.5.1rc1"
+version = "26.7.2"
 description = "Get lightcurve of objects from ZTF and ATLAS surveys"
 authors = ["Diego Rodriguez Mancini"]
 readme = "README.md"

--- a/lightcurve/src/database/sql.py
+++ b/lightcurve/src/database/sql.py
@@ -22,7 +22,17 @@ def connect() -> Engine:
     # NullPool: pgbouncer already does transaction pooling in front of
     # Postgres, so an app-side pool would double-pool. This is not "a new
     # connection per request per Postgres" -- it means no *second* pool.
-    engine: Engine = create_engine(db_url, echo=False, poolclass=NullPool)
+    #
+    # AUTOCOMMIT: Postgres is on-prem in Chile, ~134 ms from the cluster, and
+    # psycopg2's implicit BEGIN and the pool's reset-on-return ROLLBACK are
+    # each a full round trip -- 3 per read where the query needs 1. These
+    # sub-apps are read-only (no INSERT/UPDATE/DELETE, no FOR UPDATE, no temp
+    # tables, no server-side cursors) and every service call already opens its
+    # own session, so per-statement visibility is what they get today anyway.
+    # Measured: -260 ms per read, -1308 ms over the 5 reads of htmx/lightcurve.
+    engine: Engine = create_engine(
+        db_url, echo=False, poolclass=NullPool, isolation_level="AUTOCOMMIT"
+    )
     return engine
 
 

--- a/lightcurve/src/database/sql.py
+++ b/lightcurve/src/database/sql.py
@@ -5,6 +5,7 @@ from typing import Generator
 
 from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,10 @@ db_url = f"postgresql://{user}:{pwd}@{host}:{port}/{db}"
 
 
 def connect() -> Engine:
-    engine: Engine = create_engine(db_url, echo=False)
+    # NullPool: pgbouncer already does transaction pooling in front of
+    # Postgres, so an app-side pool would double-pool. This is not "a new
+    # connection per request per Postgres" -- it means no *second* pool.
+    engine: Engine = create_engine(db_url, echo=False, poolclass=NullPool)
     return engine
 
 


### PR DESCRIPTION
Rec 1 of the lightcurve latency investigation, for `ws-lightcurve`. Two commits, one behavioural change.

| commit | change | effect on production |
|---|---|---|
| `d4e1d0d78` | `poolclass=NullPool` | **none** — production already runs this; the line was never merged |
| `8dc146c61` | `isolation_level="AUTOCOMMIT"` | the only thing users feel |

The first commit exists because the deployed image was hand-built off-`main` (tag `rc-nullpool`, 26/07/2026) and carries `NullPool` in a commit that does not exist. Building rec 1 from `main` without it would silently revert `NullPool` in the same release that introduces autocommit — two changes, one invisible in the diff, and any regression un-attributable. Keeping them as separate commits preserves that attribution in history while the *release* still carries exactly one behavioural change.

## Why autocommit

Postgres is on-prem in Chile, **128–134 ms** from the cluster. PostgreSQL's own contribution to these endpoints is **0.1–2.4 ms per query**, every plan an index scan — there is no missing index and no bad plan. The cost is round trips: psycopg2 sends an implicit `BEGIN` and waits, then the query, then SQLAlchemy's `reset_on_return='rollback'` sends a `ROLLBACK` on `session.close()`. Three trips where the query needs one, five reads per htmx request, each in its own session: **15–20 round trips ≈ 2.0–2.7 s of pure protocol** before any science data moves.

`isolation_level="AUTOCOMMIT"` sets psycopg2's `connection.autocommit` in SQLAlchemy's `on_connect` handler — client-side, no SQL, no round trip.

## Measured, not inferred

In-pod A/B through the app's own `session_wrapper`, both engine shapes built in a **second process** so the serving app was untouched. Medians of n=3, calls alternated inside one interleaved loop to cancel drift:

| service call | today | autocommit | saved | rows |
|---|---:|---:|---:|---:|
| `get_detections` | 551.7 | 294.8 | **−256.9** | 1357 |
| `get_non_detections` | 484.1 | 220.0 | **−264.1** | 976 |
| `get_forced_photometry` | 521.6 | 257.6 | **−264.0** | 370 |
| `query_psql_object` | 501.7 | 235.3 | **−266.4** | 1 |
| `get_period` | 512.0 | 255.0 | **−257.0** | 21 |
| **total** | **2571.0** | **1262.6** | **−1308.4** | |

Data identical on every call. The saving is **constant per read** — 1357 rows and 1 row both save ~260 ms — which is the signature of removing protocol round trips rather than work. Autocommit was verified at the protocol level, not from the clock: psycopg2's transaction-status byte reads `IDLE` instead of `INTRANS`, and `now()` (the *transaction* timestamp) starts differing between two statements in one session. Replicated on a second run: **3006.7 → 1962.4 ms**, ratio **2.01×** both times.

Expected end state: ZTF htmx **~3.7 s → ~2.4 s**.

## Semantics: non-regressive

- The app **already** opens five separate sessions per request — five snapshots, possibly on five backends. Autocommit does not give up a cross-query snapshot, because there has never been one.
- Nothing in `src/` writes. Verified by grep across all five sub-apps: no `INSERT`/`UPDATE`/`DELETE`, no `session.add`/`commit`/`flush`, no `FOR UPDATE`, no temp tables, no server-side/streaming cursors (`stream_results`, `yield_per`), no `SET LOCAL`, no advisory locks, no `execution_options`. The only write in the tree is `scripts/create_q3c_index.py`, reachable from `scripts/initdb.py`, which sets AUTOCOMMIT itself.
- Statement-level atomicity is untouched.
- **Easier on the shared pooler, not harder.** pgbouncer is in transaction pooling, so a backend is leased for the duration of a transaction: occupancy per read falls from **~530 ms to ~260 ms**, roughly 2× the throughput out of the same `default_pool_size`.
- Set on `create_engine`, **not** per-checkout `execution_options` (which would also have to restore the previous level on return to the pool).
- Deliberately **not** shipping `pool_reset_on_return=None`: it looked like a third free round trip in one run and like nothing at all in the next. The link has a ~130/~260 ms bimodality that tracks no engine setting, so it is unproven.

## Provenance verified against the running artifact

Not against the branch — that mistake is what commit 1 cleans up. With the pod's tree md5-compared to this branch (`lightcurve@sha256:00772bb1…ada40e4`, 3/3 pods):

- **49/49 Python files identical**, the sole exception being `database/sql.py`.
- The pod's `database/sql.py` is byte-identical to commit `d4e1d0d78` apart from the added comment.

So this branch is *production + rec 1*, with no third change riding along.

## Blast radius

`connect()` is shared by all five sub-apps in the image (`lightcurve_api`, `object_api`, `magstats_api`, `probability_api`, `crossmatch_api`) → the five `ws-*` Helm releases. Because the image pin is **per release**, only `ws-lightcurve` gets re-pinned on merge-day; the other four stay on the current digest as an untouched control until 24 h of the status prober's private `probe_latency` series confirms the win. Deploy is a manual `helm upgrade … --atomic` (3 replicas, rolling); rollback is `helm rollback ws-lightcurve 14`, ~30 s.

**Merging this does not deploy anything.** It fires `CD Lightcurve`, whose `deploy-production` job is gated on `event == 'release'` (a push is not one), and which in practice has been failing at the dagger `build` step with every downstream job skipped — the last three runs on `main` included. Expect one more red run that touches nothing.

## Test plan

- CI `lightcurve_tests` — the 15 service/API test files are the bed for "nothing depended on the implicit transaction". `tests/conftest.py` imports the real `lightcurve_api.api:app`, so `connect()`'s engine is what the API tests exercise. Commit 1 already passed this suite (green on #563, now closed in favour of this PR).
- Latency is **not** measurable locally by construction — a local Postgres answers in sub-ms. Do not read local timings as evidence either way.
- Post-deploy proof is the real endpoint timed from pod loopback, then 24 h of the prober's `metric=probe_latency` series against the four unchanged releases.

Full analysis: `planning/projects/service-performance/docs/lightcurve-latency-investigation.md` §2a, §2c, §3a, §8a, §8c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
